### PR TITLE
Change thread entry function and timer expiration function prototypes…

### DIFF
--- a/common/inc/tx_api.h
+++ b/common/inc/tx_api.h
@@ -375,8 +375,8 @@ typedef struct TX_TIMER_INTERNAL_STRUCT
     ULONG               tx_timer_internal_re_initialize_ticks;
 
     /* Define the timeout function and timeout function parameter.  */
-    VOID                (*tx_timer_internal_timeout_function)(ULONG id);
-    ULONG               tx_timer_internal_timeout_param;
+    VOID                (*tx_timer_internal_timeout_function)(ALIGN_TYPE id);
+    ALIGN_TYPE          tx_timer_internal_timeout_param;
 
 
     /* Define the next and previous internal link pointers for active
@@ -496,8 +496,8 @@ typedef struct TX_THREAD_STRUCT
        is recompiled.  */
 
     /* Define the thread's entry point and input parameter.  */
-    VOID                (*tx_thread_entry)(ULONG id);
-    ULONG               tx_thread_entry_parameter;
+    VOID                (*tx_thread_entry)(ALIGN_TYPE id);
+    ALIGN_TYPE          tx_thread_entry_parameter;
 
     /* Define the thread's timer block.   This is used for thread
        sleep and timeout requests.  */
@@ -1725,7 +1725,7 @@ UINT        _txr_semaphore_put_notify(TX_SEMAPHORE *semaphore_ptr, VOID (*semaph
 VOID        _tx_thread_context_save(VOID);
 VOID        _tx_thread_context_restore(VOID);
 UINT        _tx_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
+                VOID (*entry_function)(ALIGN_TYPE entry_input), ALIGN_TYPE entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
                 ULONG time_slice, UINT auto_start);
@@ -1762,7 +1762,7 @@ UINT        _tx_thread_wait_abort(TX_THREAD *thread_ptr);
    application.  */
 
 UINT        _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
+                VOID (*entry_function)(ALIGN_TYPE entry_input), ALIGN_TYPE entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
                 ULONG time_slice, UINT auto_start, UINT thread_control_block_size);
@@ -1784,7 +1784,7 @@ UINT        _txe_thread_time_slice_change(TX_THREAD *thread_ptr, ULONG new_time_
 UINT        _txe_thread_wait_abort(TX_THREAD *thread_ptr);
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
 UINT        _txr_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
+                VOID (*entry_function)(ALIGN_TYPE entry_input), ALIGN_TYPE entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
                 ULONG time_slice, UINT auto_start, UINT thread_control_block_size);
@@ -1811,7 +1811,7 @@ UINT        _txr_thread_wait_abort(TX_THREAD *thread_ptr);
 UINT        _tx_timer_activate(TX_TIMER *timer_ptr);
 UINT        _tx_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
 UINT        _tx_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-                VOID (*expiration_function)(ULONG input), ULONG expiration_input,
+                VOID (*expiration_function)(ALIGN_TYPE input), ALIGN_TYPE expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate);
 UINT        _tx_timer_deactivate(TX_TIMER *timer_ptr);
 UINT        _tx_timer_delete(TX_TIMER *timer_ptr);
@@ -1832,7 +1832,7 @@ VOID        _tx_time_set(ULONG new_time);
 UINT        _txe_timer_activate(TX_TIMER *timer_ptr);
 UINT        _txe_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
 UINT        _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-                VOID (*expiration_function)(ULONG input), ULONG expiration_input,
+                VOID (*expiration_function)(ALIGN_TYPE input), ALIGN_TYPE expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 UINT        _txe_timer_deactivate(TX_TIMER *timer_ptr);
 UINT        _txe_timer_delete(TX_TIMER *timer_ptr);
@@ -1842,7 +1842,7 @@ UINT        _txe_timer_info_get(TX_TIMER *timer_ptr, CHAR **name, UINT *active, 
 UINT        _txr_timer_activate(TX_TIMER *timer_ptr);
 UINT        _txr_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
 UINT        _txr_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-                VOID (*expiration_function)(ULONG input), ULONG expiration_input,
+                VOID (*expiration_function)(ALIGN_TYPE input), ALIGN_TYPE expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 UINT        _txr_timer_deactivate(TX_TIMER *timer_ptr);
 UINT        _txr_timer_delete(TX_TIMER *timer_ptr);

--- a/common/inc/tx_thread.h
+++ b/common/inc/tx_thread.h
@@ -137,7 +137,7 @@
 
 #ifndef TX_THREAD_CREATE_TIMEOUT_SETUP
 #define TX_THREAD_CREATE_TIMEOUT_SETUP(t)    (t) -> tx_thread_timer.tx_timer_internal_timeout_function =  &(_tx_thread_timeout);                \
-                                             (t) -> tx_thread_timer.tx_timer_internal_timeout_param =     TX_POINTER_TO_ULONG_CONVERT((t));
+                                             (t) -> tx_thread_timer.tx_timer_internal_timeout_param =     TX_POINTER_TO_ALIGN_TYPE_CONVERT((t));
 #endif
 
 

--- a/common/src/tx_thread_create.c
+++ b/common/src/tx_thread_create.c
@@ -90,7 +90,7 @@
 /*                                            resulting in version 6.1.8  */
 /*                                                                        */
 /**************************************************************************/
-UINT  _tx_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr, VOID (*entry_function)(ULONG id), ULONG entry_input,
+UINT  _tx_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr, VOID (*entry_function)(ALIGN_TYPE id), ALIGN_TYPE entry_input,
                             VOID *stack_start, ULONG stack_size, UINT priority, UINT preempt_threshold,
                             ULONG time_slice, UINT auto_start)
 {

--- a/common/src/tx_timer_create.c
+++ b/common/src/tx_timer_create.c
@@ -76,7 +76,7 @@
 /*                                                                        */
 /**************************************************************************/
 UINT  _tx_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-            VOID (*expiration_function)(ULONG id), ULONG expiration_input,
+            VOID (*expiration_function)(ALIGN_TYPE id), ALIGN_TYPE expiration_input,
             ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate)
 {
 

--- a/common/src/tx_timer_expiration_process.c
+++ b/common/src/tx_timer_expiration_process.c
@@ -96,8 +96,8 @@ UINT                        expiration_time;            /* Value used for pointe
 ULONG                       delta;
 #endif
 TX_TIMER_INTERNAL           *current_timer;
-VOID                        (*timeout_function)(ULONG id);
-ULONG                       timeout_param =  ((ULONG) 0);
+VOID                        (*timeout_function)(ALIGN_TYPE id);
+ALIGN_TYPE                  timeout_param =  ((ALIGN_TYPE) 0);
 #ifdef TX_TIMER_ENABLE_PERFORMANCE_INFO
 TX_TIMER                    *timer_ptr;
 #endif

--- a/common/src/tx_timer_thread_entry.c
+++ b/common/src/tx_timer_thread_entry.c
@@ -84,8 +84,8 @@ TX_TIMER_INTERNAL           *reactivate_timer;
 TX_TIMER_INTERNAL           *next_timer;
 TX_TIMER_INTERNAL           *previous_timer;
 TX_TIMER_INTERNAL           *current_timer;
-VOID                        (*timeout_function)(ULONG id);
-ULONG                       timeout_param =  ((ULONG) 0);
+VOID                        (*timeout_function)(ALIGN_TYPE id);
+ALIGN_TYPE                  timeout_param =  ((ALIGN_TYPE) 0);
 TX_THREAD                   *thread_ptr;
 #ifdef TX_REACTIVATE_INLINE
 TX_TIMER_INTERNAL           **timer_list;               /* Timer list pointer           */

--- a/common/src/txe_thread_create.c
+++ b/common/src/txe_thread_create.c
@@ -88,7 +88,7 @@
 /*                                                                        */
 /**************************************************************************/
 UINT    _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                VOID (*entry_function)(ULONG id), ULONG entry_input,
+                VOID (*entry_function)(ALIGN_TYPE id), ALIGN_TYPE entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
                 ULONG time_slice, UINT auto_start, UINT thread_control_block_size)

--- a/common/src/txe_timer_create.c
+++ b/common/src/txe_timer_create.c
@@ -83,7 +83,7 @@
 /*                                                                        */
 /**************************************************************************/
 UINT  _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-            VOID (*expiration_function)(ULONG id), ULONG expiration_input,
+            VOID (*expiration_function)(ALIGN_TYPE id), ALIGN_TYPE expiration_input,
             ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size)
 {
 

--- a/common_modules/module_lib/src/txm_thread_create.c
+++ b/common_modules/module_lib/src/txm_thread_create.c
@@ -79,7 +79,7 @@
 /*                                            resulting in version 6.1.10 */
 /*                                                                        */
 /**************************************************************************/
-UINT _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr, VOID (*entry_function)(ULONG entry_input), ULONG entry_input, VOID *stack_start, ULONG stack_size, UINT priority, UINT preempt_threshold, ULONG time_slice, UINT auto_start, UINT thread_control_block_size)
+UINT _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr, VOID (*entry_function)(ALIGN_TYPE entry_input), ALIGN_TYPE entry_input, VOID *stack_start, ULONG stack_size, UINT priority, UINT preempt_threshold, ULONG time_slice, UINT auto_start, UINT thread_control_block_size)
 {
 
 UINT return_value;

--- a/common_modules/module_lib/src/txm_timer_create.c
+++ b/common_modules/module_lib/src/txm_timer_create.c
@@ -74,7 +74,7 @@
 /*                                            resulting in version 6.1.10 */
 /*                                                                        */
 /**************************************************************************/
-UINT _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr, VOID (*expiration_function)(ULONG), ULONG expiration_input, ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size)
+UINT _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr, VOID (*expiration_function)(ALIGN_TYPE), ALIGN_TYPE expiration_input, ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size)
 {
 
 UINT return_value;

--- a/common_modules/module_manager/inc/txm_module_manager_dispatch.h
+++ b/common_modules/module_manager/inc/txm_module_manager_dispatch.h
@@ -2039,8 +2039,8 @@ ALIGN_TYPE return_value;
         (TX_THREAD *) param_0,
         (CHAR *) param_1,
         module_instance -> txm_module_instance_shell_entry_function,
-        (VOID (*)(ULONG entry_input)) extra_parameters[0],
-        (ULONG) extra_parameters[1],
+        (VOID (*)(ALIGN_TYPE entry_input)) extra_parameters[0],
+        (ALIGN_TYPE) extra_parameters[1],
         (VOID *) extra_parameters[2],
         (ULONG) extra_parameters[3],
         (UINT) extra_parameters[4],
@@ -2768,7 +2768,7 @@ static ALIGN_TYPE _txm_module_manager_tx_timer_create_dispatch(TXM_MODULE_INSTAN
 
 ALIGN_TYPE return_value;
 TX_TIMER *timer_ptr;
-VOID (*expiration_function)(ULONG);
+VOID (*expiration_function)(ALIGN_TYPE);
 
     if (module_instance -> txm_module_instance_property_flags & TXM_MODULE_MEMORY_PROTECTION)
     {

--- a/common_modules/module_manager/src/txm_module_manager_thread_create.c
+++ b/common_modules/module_manager/src/txm_module_manager_thread_create.c
@@ -98,7 +98,7 @@
 /**************************************************************************/
 UINT  _txm_module_manager_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
                             VOID (*shell_function)(TX_THREAD *, TXM_MODULE_INSTANCE *),
-                            VOID (*entry_function)(ULONG id), ULONG entry_input,
+                            VOID (*entry_function)(ALIGN_TYPE id), ALIGN_TYPE entry_input,
                             VOID *stack_start, ULONG stack_size, UINT priority, UINT preempt_threshold,
                             ULONG time_slice, UINT auto_start,
                             UINT thread_control_block_size, TXM_MODULE_INSTANCE *module_instance)

--- a/common_smp/inc/tx_api.h
+++ b/common_smp/inc/tx_api.h
@@ -376,8 +376,8 @@ typedef struct TX_TIMER_INTERNAL_STRUCT
     ULONG               tx_timer_internal_re_initialize_ticks;
 
     /* Define the timeout function and timeout function parameter.  */
-    VOID                (*tx_timer_internal_timeout_function)(ULONG id);
-    ULONG               tx_timer_internal_timeout_param;
+    VOID                (*tx_timer_internal_timeout_function)(ALIGN_TYPE id);
+    ALIGN_TYPE          tx_timer_internal_timeout_param;
 
 
     /* Define the next and previous internal link pointers for active
@@ -512,8 +512,8 @@ typedef struct TX_THREAD_STRUCT
        is recompiled.  */
 
     /* Define the thread's entry point and input parameter.  */
-    VOID                (*tx_thread_entry)(ULONG id);
-    ULONG               tx_thread_entry_parameter;
+    VOID                (*tx_thread_entry)(ALIGN_TYPE id);
+    ALIGN_TYPE          tx_thread_entry_parameter;
 
     /* Define the thread's timer block.   This is used for thread
        sleep and timeout requests.  */
@@ -1752,7 +1752,7 @@ UINT        _txe_semaphore_put_notify(TX_SEMAPHORE *semaphore_ptr, VOID (*semaph
 VOID        _tx_thread_context_save(VOID);
 VOID        _tx_thread_context_restore(VOID);
 UINT        _tx_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
+                VOID (*entry_function)(ALIGN_TYPE entry_input), ALIGN_TYPE entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
                 ULONG time_slice, UINT auto_start);
@@ -1789,7 +1789,7 @@ UINT        _tx_thread_wait_abort(TX_THREAD *thread_ptr);
    application.  */
 
 UINT        _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
+                VOID (*entry_function)(ALIGN_TYPE entry_input), ALIGN_TYPE entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
                 ULONG time_slice, UINT auto_start, UINT thread_control_block_size);
@@ -1816,7 +1816,7 @@ UINT        _txe_thread_wait_abort(TX_THREAD *thread_ptr);
 UINT        _tx_timer_activate(TX_TIMER *timer_ptr);
 UINT        _tx_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
 UINT        _tx_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-                VOID (*expiration_function)(ULONG input), ULONG expiration_input,
+                VOID (*expiration_function)(ALIGN_TYPE input), ALIGN_TYPE expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate);
 UINT        _tx_timer_deactivate(TX_TIMER *timer_ptr);
 UINT        _tx_timer_delete(TX_TIMER *timer_ptr);
@@ -1837,7 +1837,7 @@ VOID        _tx_time_set(ULONG new_time);
 UINT        _txe_timer_activate(TX_TIMER *timer_ptr);
 UINT        _txe_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
 UINT        _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-                VOID (*expiration_function)(ULONG input), ULONG expiration_input,
+                VOID (*expiration_function)(ALIGN_TYPE input), ALIGN_TYPE expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 UINT        _txe_timer_deactivate(TX_TIMER *timer_ptr);
 UINT        _txe_timer_delete(TX_TIMER *timer_ptr);

--- a/common_smp/inc/tx_thread.h
+++ b/common_smp/inc/tx_thread.h
@@ -509,7 +509,7 @@ THREAD_DECLARE  ULONG                       _tx_thread_performance_non_idle_retu
 
 #ifndef TX_THREAD_CREATE_TIMEOUT_SETUP
 #define TX_THREAD_CREATE_TIMEOUT_SETUP(t)    (t) -> tx_thread_timer.tx_timer_internal_timeout_function =  &(_tx_thread_timeout);                \
-                                             (t) -> tx_thread_timer.tx_timer_internal_timeout_param =     TX_POINTER_TO_ULONG_CONVERT((t));
+                                             (t) -> tx_thread_timer.tx_timer_internal_timeout_param =     TX_POINTER_TO_ALIGN_TYPE_CONVERT((t));
 #endif
 
 

--- a/common_smp/src/tx_thread_create.c
+++ b/common_smp/src/tx_thread_create.c
@@ -92,7 +92,7 @@
 /*                                                                        */
 /**************************************************************************/
 UINT  _tx_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                            VOID (*entry_function)(ULONG id), ULONG entry_input,
+                            VOID (*entry_function)(ALIGN_TYPE id), ALIGN_TYPE entry_input,
                             VOID *stack_start, ULONG stack_size, UINT priority, UINT preempt_threshold,
                             ULONG time_slice, UINT auto_start)
 {

--- a/common_smp/src/tx_timer_create.c
+++ b/common_smp/src/tx_timer_create.c
@@ -75,7 +75,7 @@
 /*                                                                        */
 /**************************************************************************/
 UINT  _tx_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-            VOID (*expiration_function)(ULONG id), ULONG expiration_input,
+            VOID (*expiration_function)(ALIGN_TYPE id), ALIGN_TYPE expiration_input,
             ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate)
 {
 

--- a/common_smp/src/tx_timer_expiration_process.c
+++ b/common_smp/src/tx_timer_expiration_process.c
@@ -91,8 +91,8 @@ UINT                        expiration_time;            /* Value used for pointe
 ULONG                       delta;
 #endif
 TX_TIMER_INTERNAL           *current_timer;
-VOID                        (*timeout_function)(ULONG id);
-ULONG                       timeout_param =  ((ULONG) 0);
+VOID                        (*timeout_function)(ALIGN_TYPE id);
+ALIGN_TYPE                  timeout_param =  ((ALIGN_TYPE) 0);
 #ifdef TX_TIMER_ENABLE_PERFORMANCE_INFO
 TX_TIMER                    *timer_ptr;
 #endif

--- a/common_smp/src/tx_timer_thread_entry.c
+++ b/common_smp/src/tx_timer_thread_entry.c
@@ -84,8 +84,8 @@ TX_TIMER_INTERNAL           *reactivate_timer;
 TX_TIMER_INTERNAL           *next_timer;
 TX_TIMER_INTERNAL           *previous_timer;
 TX_TIMER_INTERNAL           *current_timer;
-VOID                        (*timeout_function)(ULONG id);
-ULONG                       timeout_param =  ((ULONG) 0);
+VOID                        (*timeout_function)(ALIGN_TYPE id);
+ALIGN_TYPE                  timeout_param =  ((ALIGN_TYPE) 0);
 TX_THREAD                   *thread_ptr;
 #ifdef TX_REACTIVATE_INLINE
 TX_TIMER_INTERNAL           **timer_list;               /* Timer list pointer           */

--- a/common_smp/src/txe_thread_create.c
+++ b/common_smp/src/txe_thread_create.c
@@ -88,7 +88,7 @@
 /*                                                                        */
 /**************************************************************************/
 UINT    _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
-                VOID (*entry_function)(ULONG id), ULONG entry_input,
+                VOID (*entry_function)(ALIGN_TYPE id), ALIGN_TYPE entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
                 ULONG time_slice, UINT auto_start, UINT thread_control_block_size)

--- a/common_smp/src/txe_timer_create.c
+++ b/common_smp/src/txe_timer_create.c
@@ -83,7 +83,7 @@
 /*                                                                        */
 /**************************************************************************/
 UINT  _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
-            VOID (*expiration_function)(ULONG id), ULONG expiration_input,
+            VOID (*expiration_function)(ALIGN_TYPE id), ALIGN_TYPE expiration_input,
             ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size)
 {
 

--- a/ports/arc_em/metaware/example_build/sample_threadx/sample_threadx.c
+++ b/ports/arc_em/metaware/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/arc_hs/metaware/example_build/sample_threadx/sample_threadx.c
+++ b/ports/arc_hs/metaware/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/arm11/ac5/example_build/sample_threadx.c
+++ b/ports/arm11/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/arm11/gnu/example_build/sample_threadx.c
+++ b/ports/arm11/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/arm11/iar/example_build/sample_threadx.c
+++ b/ports/arm11/iar/example_build/sample_threadx.c
@@ -49,12 +49,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -179,7 +179,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -205,7 +205,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -231,7 +231,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -258,7 +258,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -295,7 +295,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -320,7 +320,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/arm9/ac5/example_build/sample_threadx.c
+++ b/ports/arm9/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/arm9/gnu/example_build/sample_threadx.c
+++ b/ports/arm9/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/arm9/iar/example_build/sample_threadx.c
+++ b/ports/arm9/iar/example_build/sample_threadx.c
@@ -49,12 +49,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -179,7 +179,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -205,7 +205,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -231,7 +231,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -258,7 +258,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -295,7 +295,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -320,7 +320,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/c667x/ccs/example_build/sample_threadx_c6678evm/sample_threadx.c
+++ b/ports/c667x/ccs/example_build/sample_threadx_c6678evm/sample_threadx.c
@@ -59,12 +59,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 void    my_stack_error_handler(TX_THREAD *thread_ptr);
 void    my_timer_function(ULONG timer_input);
 
@@ -89,7 +89,7 @@ void    tx_application_define(void *first_unused_memory)
 CHAR    *pointer = TX_NULL;
 UINT    status;
 
-	/* Enable event tracing using the global “trace_buffer” memory and supporting
+	/* Enable event tracing using the global ï¿½trace_bufferï¿½ memory and supporting
    	   a maximum of TRACE_OBJECTS_COUNT ThreadX objects in the registry.  */
 	if ((status = tx_trace_enable(tx_trace_buffer, TRACE_BUFFER_SIZE, TRACE_OBJECTS_COUNT)) != TX_SUCCESS)
 	{
@@ -305,7 +305,7 @@ UINT    status;
 	}
 
     /* Create the periodic timer. */
-	status = tx_timer_create(&timer_0, "timer 0", my_timer_function, (ULONG) DEMO_TIMER_VALUE, DEMO_TIMER_PERIOD, DEMO_TIMER_PERIOD, TX_AUTO_ACTIVATE);
+	status = tx_timer_create(&timer_0, "timer 0", my_timer_function, (ALIGN_TYPE) DEMO_TIMER_VALUE, DEMO_TIMER_PERIOD, DEMO_TIMER_PERIOD, TX_AUTO_ACTIVATE);
 	if (status != TX_SUCCESS)
 	{
 		while (1);
@@ -316,7 +316,7 @@ UINT    status;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -342,7 +342,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -368,7 +368,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -395,7 +395,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -432,7 +432,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -457,7 +457,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -517,7 +517,7 @@ void my_stack_error_handler(TX_THREAD *thread_ptr)
 }
 
 
-void my_timer_function(ULONG timer_input)
+void my_timer_function(ALIGN_TYPE timer_input)
 {
     /* Increment the thread counter.  */
     timer_0_counter++;

--- a/ports/c667x/ccs/example_build/sample_threadx_ta6678fmc/sample_threadx.c
+++ b/ports/c667x/ccs/example_build/sample_threadx_ta6678fmc/sample_threadx.c
@@ -59,12 +59,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 void    my_stack_error_handler(TX_THREAD *thread_ptr);
 void    my_timer_function(ULONG timer_input);
 
@@ -89,7 +89,7 @@ void    tx_application_define(void *first_unused_memory)
 CHAR    *pointer = TX_NULL;
 UINT    status;
 
-	/* Enable event tracing using the global “trace_buffer” memory and supporting
+	/* Enable event tracing using the global ï¿½trace_bufferï¿½ memory and supporting
    	   a maximum of TRACE_OBJECTS_COUNT ThreadX objects in the registry.  */
 	if ((status = tx_trace_enable(tx_trace_buffer, TRACE_BUFFER_SIZE, TRACE_OBJECTS_COUNT)) != TX_SUCCESS)
 	{
@@ -305,7 +305,7 @@ UINT    status;
 	}
 
     /* Create the periodic timer. */
-	status = tx_timer_create(&timer_0, "timer 0", my_timer_function, (ULONG) DEMO_TIMER_VALUE, DEMO_TIMER_PERIOD, DEMO_TIMER_PERIOD, TX_AUTO_ACTIVATE);
+	status = tx_timer_create(&timer_0, "timer 0", my_timer_function, (ALIGN_TYPE) DEMO_TIMER_VALUE, DEMO_TIMER_PERIOD, DEMO_TIMER_PERIOD, TX_AUTO_ACTIVATE);
 	if (status != TX_SUCCESS)
 	{
 		while (1);
@@ -316,7 +316,7 @@ UINT    status;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -342,7 +342,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -368,7 +368,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -395,7 +395,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -432,7 +432,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -457,7 +457,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -517,7 +517,7 @@ void my_stack_error_handler(TX_THREAD *thread_ptr)
 }
 
 
-void my_timer_function(ULONG timer_input)
+void my_timer_function(ALIGN_TYPE timer_input)
 {
     /* Increment the thread counter.  */
     timer_0_counter++;

--- a/ports/cortex_a12/ac6/example_build/sample_threadx.c
+++ b/ports/cortex_a12/ac6/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a12/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a12/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a12/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_a12/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a15/ac6/example_build/sample_threadx.c
+++ b/ports/cortex_a15/ac6/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a15/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a15/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a15/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_a15/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a15/iar/example_build/sample_threadx.c
+++ b/ports/cortex_a15/iar/example_build/sample_threadx.c
@@ -47,12 +47,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -177,7 +177,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -203,7 +203,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -293,7 +293,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -318,7 +318,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a17/ac6/example_build/sample_threadx.c
+++ b/ports/cortex_a17/ac6/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a17/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a17/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a17/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_a17/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a34/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a34/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a34/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a34/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a35/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a35/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a35/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a35/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a5/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_a5/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a5/ac6/example_build/sample_threadx.c
+++ b/ports/cortex_a5/ac6/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a5/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a5/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a5/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_a5/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a5/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_a5/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a5/iar/example_build/sample_threadx.c
+++ b/ports/cortex_a5/iar/example_build/sample_threadx.c
@@ -49,12 +49,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -179,7 +179,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -205,7 +205,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -231,7 +231,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -258,7 +258,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -295,7 +295,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -320,7 +320,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a53/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a53/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a53/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a53/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a55/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a55/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a55/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a55/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a57/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a57/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a57/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a57/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a5x/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a5x/ac6/example_build/sample_threadx/sample_threadx.c
@@ -47,12 +47,12 @@ UCHAR					memory_pool[DEMO_BYTE_POOL_SIZE];
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define board-specific hardware setup.  */
@@ -185,7 +185,7 @@ UCHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -211,7 +211,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -237,7 +237,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -265,7 +265,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -302,7 +302,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -327,7 +327,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a65/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a65/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a65/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a65/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a65ae/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a65ae/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a65ae/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a65ae/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a7/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_a7/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a7/ac6/example_build/sample_threadx.c
+++ b/ports/cortex_a7/ac6/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a7/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a7/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a7/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_a7/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a7/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_a7/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a7/iar/example_build/sample_threadx.c
+++ b/ports/cortex_a7/iar/example_build/sample_threadx.c
@@ -47,12 +47,12 @@ UCHAR           memory_pool[DEMO_BYTE_POOL_SIZE];
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -177,7 +177,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -203,7 +203,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -293,7 +293,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -318,7 +318,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a72/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a72/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a72/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a72/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a73/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a73/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a73/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a73/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a75/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a75/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a75/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a75/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a76/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a76/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a76/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a76/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a76ae/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a76ae/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a76ae/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a76ae/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a77/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a77/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a77/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a77/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a8/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_a8/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a8/ac6/example_build/sample_threadx.c
+++ b/ports/cortex_a8/ac6/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a8/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a8/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a8/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_a8/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a8/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_a8/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a8/iar/example_build/sample_threadx.c
+++ b/ports/cortex_a8/iar/example_build/sample_threadx.c
@@ -47,12 +47,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -177,7 +177,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -203,7 +203,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -293,7 +293,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -318,7 +318,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a9/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_a9/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a9/ac6/example_build/sample_threadx.c
+++ b/ports/cortex_a9/ac6/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a9/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_a9/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a9/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_a9/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a9/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_a9/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_a9/iar/example_build/sample_threadx.c
+++ b/ports/cortex_a9/iar/example_build/sample_threadx.c
@@ -47,12 +47,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -177,7 +177,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -203,7 +203,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -293,7 +293,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -318,7 +318,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m0/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_m0/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m0/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_m0/ac6/example_build/sample_threadx/sample_threadx.c
@@ -47,12 +47,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -177,7 +177,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -203,7 +203,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -293,7 +293,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -318,7 +318,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m0/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_m0/gnu/example_build/sample_threadx.c
@@ -47,12 +47,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -177,7 +177,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -203,7 +203,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -293,7 +293,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -318,7 +318,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m0/iar/example_build/sample_threadx.c
+++ b/ports/cortex_m0/iar/example_build/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -190,7 +190,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -216,7 +216,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -242,7 +242,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -269,7 +269,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -306,7 +306,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -331,7 +331,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m0/keil/example_build/sample_threadx.c
+++ b/ports/cortex_m0/keil/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m23/ac6/example_build/demo_threadx_non-secure_zone/demo_threadx.c
+++ b/ports/cortex_m23/ac6/example_build/demo_threadx_non-secure_zone/demo_threadx.c
@@ -57,12 +57,12 @@ static ULONG                    thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -222,7 +222,7 @@ static int callbackA (int val)
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 UINT    status;
 INT     test_secure;
@@ -257,7 +257,7 @@ INT     test_secure;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -283,7 +283,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -312,7 +312,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -348,7 +348,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -374,7 +374,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m3/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_m3/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m3/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_m3/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m3/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_m3/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m3/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_m3/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m3/iar/example_build/sample_threadx.c
+++ b/ports/cortex_m3/iar/example_build/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -190,7 +190,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -216,7 +216,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -242,7 +242,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -269,7 +269,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -306,7 +306,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -331,7 +331,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m3/keil/example_build/sample_threadx.c
+++ b/ports/cortex_m3/keil/example_build/sample_threadx.c
@@ -48,11 +48,11 @@ UCHAR                   queue_0_area[DEMO_QUEUE_SIZE*sizeof(ULONG)];
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
 
 
 volatile unsigned int bootloop;
@@ -122,7 +122,7 @@ void    tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -147,7 +147,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -173,7 +173,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -237,7 +237,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m33/ac6/example_build/demo_threadx_non-secure_zone/demo_threadx.c
+++ b/ports/cortex_m33/ac6/example_build/demo_threadx_non-secure_zone/demo_threadx.c
@@ -57,12 +57,12 @@ static ULONG                    thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 /* Define main entry point.  */
 
@@ -203,7 +203,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 UINT    status;
     
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -321,7 +321,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m4/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_m4/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m4/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_m4/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m4/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_m4/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m4/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_m4/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m4/iar/example_build/sample_threadx.c
+++ b/ports/cortex_m4/iar/example_build/sample_threadx.c
@@ -57,12 +57,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -194,7 +194,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -220,7 +220,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -246,7 +246,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -273,7 +273,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -335,7 +335,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m4/keil/example_build/demo_threadx.c
+++ b/ports/cortex_m4/keil/example_build/demo_threadx.c
@@ -48,11 +48,11 @@ UCHAR                   queue_0_area[DEMO_QUEUE_SIZE*sizeof(ULONG)];
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
 
 
 volatile unsigned int bootloop;
@@ -122,7 +122,7 @@ void    tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -147,7 +147,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -173,7 +173,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -237,7 +237,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m55/ac6/example_build/demo_threadx_non-secure_zone/demo_threadx.c
+++ b/ports/cortex_m55/ac6/example_build/demo_threadx_non-secure_zone/demo_threadx.c
@@ -57,12 +57,12 @@ static ULONG                    thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 /* Define main entry point.  */
 
@@ -203,7 +203,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 UINT    status;
     
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -256,7 +256,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -321,7 +321,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m7/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_m7/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m7/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_m7/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m7/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_m7/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m7/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_m7/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_m7/iar/example_build/sample_threadx.c
+++ b/ports/cortex_m7/iar/example_build/sample_threadx.c
@@ -53,12 +53,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -186,7 +186,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -212,7 +212,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -238,7 +238,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -265,7 +265,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -302,7 +302,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -327,7 +327,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r4/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_r4/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r4/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_r4/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 /* Define main entry point.  */
 
@@ -178,7 +178,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -204,7 +204,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -230,7 +230,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -257,7 +257,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -294,7 +294,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -319,7 +319,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r4/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_r4/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r4/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_r4/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r4/iar/example_build/sample_threadx.c
+++ b/ports/cortex_r4/iar/example_build/sample_threadx.c
@@ -51,12 +51,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -181,7 +181,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -207,7 +207,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -233,7 +233,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -260,7 +260,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -297,7 +297,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -322,7 +322,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r5/ac5/example_build/sample_threadx.c
+++ b/ports/cortex_r5/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r5/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports/cortex_r5/ac6/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r5/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_r5/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r5/gnu/example_build/sample_threadx.c
+++ b/ports/cortex_r5/gnu/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r5/iar/example_build/sample_threadx.c
+++ b/ports/cortex_r5/iar/example_build/sample_threadx.c
@@ -51,12 +51,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -181,7 +181,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -207,7 +207,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -233,7 +233,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -260,7 +260,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -297,7 +297,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -322,7 +322,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/cortex_r7/ghs/example_build/sample_threadx.c
+++ b/ports/cortex_r7/ghs/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/linux/gnu/example_build/sample_threadx.c
+++ b/ports/linux/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -211,7 +211,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -237,7 +237,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -264,7 +264,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -301,7 +301,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -326,7 +326,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/risc-v32/iar/example_build/sample_threadx.c
+++ b/ports/risc-v32/iar/example_build/sample_threadx.c
@@ -57,12 +57,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -193,7 +193,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -219,7 +219,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -245,7 +245,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -272,7 +272,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -309,7 +309,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -334,7 +334,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/win32/vs_2019/example_build/sample_threadx/sample_threadx.c
+++ b/ports/win32/vs_2019/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -212,7 +212,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -238,7 +238,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -265,7 +265,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -302,7 +302,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -327,7 +327,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports/xtensa/xcc/example_build/demo_threadx.c
+++ b/ports/xtensa/xcc/example_build/demo_threadx.c
@@ -48,12 +48,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -178,7 +178,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -208,7 +208,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -234,7 +234,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -261,7 +261,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -298,7 +298,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -323,7 +323,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_a35/ac6/example_build/sample_threadx/sample_threadx.c
@@ -47,12 +47,12 @@ UCHAR					memory_pool[DEMO_BYTE_POOL_SIZE];
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void init_timer();
 
@@ -181,7 +181,7 @@ UCHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -207,7 +207,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -233,7 +233,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -261,7 +261,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -298,7 +298,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -323,7 +323,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_a35/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends = 0;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -272,7 +272,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -297,7 +297,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -323,7 +323,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -349,7 +349,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -386,7 +386,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -411,7 +411,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_a35/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -40,7 +40,7 @@ ULONG                   memory_faults = 0;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -70,7 +70,7 @@ ULONG simple_thread_counter = 0;
 TX_THREAD simple_thread;
 #define SIMPLE_THREAD_STACK_SIZE (1024 * 4)
 ALIGN_TYPE simple_thread_stack[SIMPLE_THREAD_STACK_SIZE / sizeof(ALIGN_TYPE)];
-void simple_thread_entry(ULONG thread_input)
+void simple_thread_entry(ALIGN_TYPE thread_input)
 {
     while(1)
     {
@@ -105,7 +105,7 @@ void tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void module_manager_entry(ULONG thread_input)
+void module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_a35/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_a35/gnu/example_build/sample_threadx/sample_threadx.c
@@ -47,12 +47,12 @@ UCHAR					memory_pool[DEMO_BYTE_POOL_SIZE];
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void init_timer();
 
@@ -181,7 +181,7 @@ UCHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -207,7 +207,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -233,7 +233,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -261,7 +261,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -298,7 +298,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -323,7 +323,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35/gnu/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_a35/gnu/example_build/sample_threadx_module/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends = 0;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -272,7 +272,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -297,7 +297,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -323,7 +323,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -349,7 +349,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -386,7 +386,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -411,7 +411,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35/gnu/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_a35/gnu/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -40,7 +40,7 @@ ULONG                   memory_faults = 0;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -70,7 +70,7 @@ ULONG simple_thread_counter = 0;
 TX_THREAD simple_thread;
 #define SIMPLE_THREAD_STACK_SIZE (1024 * 4)
 ALIGN_TYPE simple_thread_stack[SIMPLE_THREAD_STACK_SIZE / sizeof(ALIGN_TYPE)];
-void simple_thread_entry(ULONG thread_input)
+void simple_thread_entry(ALIGN_TYPE thread_input)
 {
     while(1)
     {
@@ -105,7 +105,7 @@ void tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void module_manager_entry(ULONG thread_input)
+void module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_a35_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_a35_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -52,12 +52,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -196,7 +196,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -222,7 +222,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -248,7 +248,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -275,7 +275,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -312,7 +312,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -337,7 +337,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35_smp/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_a35_smp/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends = 0;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -272,7 +272,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -297,7 +297,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -323,7 +323,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -349,7 +349,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -386,7 +386,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -411,7 +411,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35_smp/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_a35_smp/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -40,7 +40,7 @@ ULONG                   memory_faults = 0;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -70,7 +70,7 @@ ULONG simple_thread_counter = 0;
 TX_THREAD simple_thread;
 #define SIMPLE_THREAD_STACK_SIZE (1024 * 4)
 ALIGN_TYPE simple_thread_stack[SIMPLE_THREAD_STACK_SIZE / sizeof(ALIGN_TYPE)];
-void simple_thread_entry(ULONG thread_input)
+void simple_thread_entry(ALIGN_TYPE thread_input)
 {
     while(1)
     {
@@ -105,7 +105,7 @@ void tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void module_manager_entry(ULONG thread_input)
+void module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_a35_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_a35_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -52,12 +52,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -196,7 +196,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -222,7 +222,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -248,7 +248,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -275,7 +275,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -312,7 +312,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -337,7 +337,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35_smp/gnu/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_a35_smp/gnu/example_build/sample_threadx_module/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends = 0;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -272,7 +272,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -297,7 +297,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -323,7 +323,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -349,7 +349,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -386,7 +386,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -411,7 +411,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a35_smp/gnu/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_a35_smp/gnu/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -40,7 +40,7 @@ ULONG                   memory_faults = 0;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -70,7 +70,7 @@ ULONG simple_thread_counter = 0;
 TX_THREAD simple_thread;
 #define SIMPLE_THREAD_STACK_SIZE (1024 * 4)
 ALIGN_TYPE simple_thread_stack[SIMPLE_THREAD_STACK_SIZE / sizeof(ALIGN_TYPE)];
-void simple_thread_entry(ULONG thread_input)
+void simple_thread_entry(ALIGN_TYPE thread_input)
 {
     while(1)
     {
@@ -105,7 +105,7 @@ void tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void module_manager_entry(ULONG thread_input)
+void module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_a7/ac5/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_a7/ac5/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -258,7 +258,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -284,7 +284,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -311,7 +311,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -348,7 +348,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -373,7 +373,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_a7/ac5/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_a7/ac5/example_build/sample_threadx_module_manager.c
@@ -15,7 +15,7 @@ TX_THREAD               module_manager;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 /* Define the module object pool area.  */
 UCHAR   object_memory[16384];
@@ -66,7 +66,7 @@ void    tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m0+/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_m0+/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m0+/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_m0+/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m0+/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m0+/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m0+/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_m0+/gnu/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m0+/gnu/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_m0+/gnu/example_build/sample_threadx_module/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m0+/gnu/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m0+/gnu/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -42,7 +42,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -83,7 +83,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m0+/iar/example_build/sample_threadx.c
+++ b/ports_module/cortex_m0+/iar/example_build/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -190,7 +190,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -216,7 +216,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -242,7 +242,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -269,7 +269,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -306,7 +306,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -331,7 +331,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m0+/iar/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m0+/iar/example_build/sample_threadx_module.c
@@ -66,12 +66,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -232,7 +232,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -258,7 +258,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -284,7 +284,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m0+/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m0+/iar/example_build/sample_threadx_module_manager.c
@@ -40,7 +40,7 @@ UCHAR                   module_manager_stack[DEMO_STACK_SIZE];
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -81,7 +81,7 @@ CHAR    *pointer = (CHAR*)module_manager_stack;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m23/ac6/example_build/demo_threadx_non-secure_zone/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m23/ac6/example_build/demo_threadx_non-secure_zone/sample_threadx_module_manager.c
@@ -42,7 +42,7 @@ static ULONG                    memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -83,7 +83,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     (void)thread_input;

--- a/ports_module/cortex_m23/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_m23/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -69,12 +69,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -235,7 +235,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -264,7 +264,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -320,7 +320,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -357,7 +357,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -382,7 +382,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m23/gnu/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m23/gnu/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m23/iar/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m23/iar/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m23/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m23/iar/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -64,7 +64,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m3/ac5/example_build/sample_threadx.c
+++ b/ports_module/cortex_m3/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m3/ac5/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m3/ac5/example_build/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m3/ac5/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m3/ac5/example_build/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m3/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_m3/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m3/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_m3/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m3/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m3/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m3/gnu/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m3/gnu/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m3/gnu/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m3/gnu/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -65,7 +65,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m3/iar/example_build/sample_threadx.c
+++ b/ports_module/cortex_m3/iar/example_build/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -190,7 +190,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -216,7 +216,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -242,7 +242,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -269,7 +269,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -306,7 +306,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -331,7 +331,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m3/iar/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m3/iar/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m3/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m3/iar/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -65,7 +65,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m33/ac6/example_build/demo_threadx_non-secure_zone/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m33/ac6/example_build/demo_threadx_non-secure_zone/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ static ULONG                    memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     (void)thread_input;

--- a/ports_module/cortex_m33/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_m33/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -70,12 +70,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -236,7 +236,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -265,7 +265,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -320,7 +320,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -357,7 +357,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -382,7 +382,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m33/gnu/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m33/gnu/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m33/gnu/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m33/gnu/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -65,7 +65,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m33/iar/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m33/iar/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m33/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m33/iar/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -64,7 +64,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m4/ac5/example_build/sample_threadx.c
+++ b/ports_module/cortex_m4/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m4/ac5/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m4/ac5/example_build/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m4/ac5/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m4/ac5/example_build/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m4/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_m4/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m4/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_m4/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m4/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m4/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m4/gnu/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m4/gnu/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m4/gnu/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m4/gnu/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -65,7 +65,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m4/iar/example_build/sample_threadx.c
+++ b/ports_module/cortex_m4/iar/example_build/sample_threadx.c
@@ -57,12 +57,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -194,7 +194,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -220,7 +220,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -246,7 +246,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -273,7 +273,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -335,7 +335,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m4/iar/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m4/iar/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m4/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m4/iar/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -64,7 +64,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m7/ac5/example_build/sample_threadx.c
+++ b/ports_module/cortex_m7/ac5/example_build/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -200,7 +200,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -226,7 +226,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -290,7 +290,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -315,7 +315,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m7/ac5/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m7/ac5/example_build/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m7/ac5/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m7/ac5/example_build/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m7/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_m7/ac6/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m7/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_m7/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -68,12 +68,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -234,7 +234,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -259,7 +259,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -285,7 +285,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -351,7 +351,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -376,7 +376,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m7/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m7/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -41,7 +41,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -82,7 +82,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m7/gnu/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m7/gnu/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -310,7 +310,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -347,7 +347,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -372,7 +372,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m7/gnu/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m7/gnu/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -65,7 +65,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_m7/iar/example_build/sample_threadx.c
+++ b/ports_module/cortex_m7/iar/example_build/sample_threadx.c
@@ -53,12 +53,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -186,7 +186,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -212,7 +212,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -238,7 +238,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -265,7 +265,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -302,7 +302,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -327,7 +327,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m7/iar/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_m7/iar/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -309,7 +309,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -346,7 +346,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -371,7 +371,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_m7/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_m7/iar/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -64,7 +64,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_module/cortex_r4/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_module/cortex_r4/ac6/example_build/sample_threadx/sample_threadx.c
@@ -46,12 +46,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -179,7 +179,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -205,7 +205,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -231,7 +231,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -258,7 +258,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -295,7 +295,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -320,7 +320,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_r4/ac6/example_build/sample_threadx_module/sample_threadx_module.c
+++ b/ports_module/cortex_r4/ac6/example_build/sample_threadx_module/sample_threadx_module.c
@@ -63,12 +63,12 @@ ULONG           thread_2_messages_received;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -229,7 +229,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -257,7 +257,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -282,7 +282,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -309,7 +309,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -346,7 +346,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -371,7 +371,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_r4/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
+++ b/ports_module/cortex_r4/ac6/example_build/sample_threadx_module_manager/sample_threadx_module_manager.c
@@ -31,7 +31,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -70,7 +70,7 @@ void    tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
     
     /* Initialize the module manager.   */

--- a/ports_module/cortex_r4/iar/example_build/sample_threadx.c
+++ b/ports_module/cortex_r4/iar/example_build/sample_threadx.c
@@ -51,12 +51,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -181,7 +181,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -207,7 +207,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -233,7 +233,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -260,7 +260,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -297,7 +297,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -322,7 +322,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_r4/iar/example_build/sample_threadx_module.c
+++ b/ports_module/cortex_r4/iar/example_build/sample_threadx_module.c
@@ -62,12 +62,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -280,7 +280,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -307,7 +307,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -344,7 +344,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -369,7 +369,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/cortex_r4/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/cortex_r4/iar/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -60,7 +60,7 @@ void    tx_application_define(void *first_unused_memory)
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
     
     /* Initialize the module manager.   */

--- a/ports_module/rxv2/iar/example_build/sample_threadx_module.c
+++ b/ports_module/rxv2/iar/example_build/sample_threadx_module.c
@@ -60,12 +60,12 @@ ULONG           queue_0_sends;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 void  semaphore_0_notify(TX_SEMAPHORE *semaphore_ptr)
 {
@@ -226,7 +226,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -252,7 +252,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -278,7 +278,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -307,7 +307,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -344,7 +344,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -369,7 +369,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_module/rxv2/iar/example_build/sample_threadx_module_manager.c
+++ b/ports_module/rxv2/iar/example_build/sample_threadx_module_manager.c
@@ -24,7 +24,7 @@ ULONG                   memory_faults;
 
 /* Define thread prototypes.  */
 
-void    module_manager_entry(ULONG thread_input);
+void    module_manager_entry(ALIGN_TYPE thread_input);
 
 
 /* Define fault handler.  */
@@ -65,7 +65,7 @@ CHAR    *pointer = (CHAR*)first_unused_memory;
 
 /* Define the test threads.  */
 
-void    module_manager_entry(ULONG thread_input)
+void    module_manager_entry(ALIGN_TYPE thread_input)
 {
 
     /* Initialize the module manager.   */

--- a/ports_smp/arc_hs_smp/metaware/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/arc_hs_smp/metaware/example_build/sample_threadx/sample_threadx.c
@@ -44,12 +44,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 void    arc_cpu_init(void);
 
 
@@ -177,7 +177,7 @@ CHAR    *pointer = TX_NULL;
 
 
 /* Define the test threads.  */
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -203,7 +203,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -229,7 +229,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -257,7 +257,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -294,7 +294,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -319,7 +319,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a34_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a34_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a34_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a34_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a35_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a35_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a35_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a35_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a53_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a53_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a53_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a53_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a55_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a55_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a55_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a55_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a57_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a57_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a57_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a57_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a5_smp/ac5/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a5_smp/ac5/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -184,7 +184,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -210,7 +210,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -236,7 +236,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -263,7 +263,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -300,7 +300,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -325,7 +325,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a5_smp/gnu/example_build/sample_threadx.c
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -184,7 +184,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -210,7 +210,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -236,7 +236,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -263,7 +263,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -300,7 +300,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -325,7 +325,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a5x_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a5x_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -53,12 +53,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -193,7 +193,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -219,7 +219,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -245,7 +245,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -272,7 +272,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -309,7 +309,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -334,7 +334,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a5x_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a5x_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -53,12 +53,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -193,7 +193,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -219,7 +219,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -245,7 +245,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -272,7 +272,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -309,7 +309,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -334,7 +334,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a5x_smp/green/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a5x_smp/green/example_build/sample_threadx/sample_threadx.c
@@ -51,12 +51,12 @@ UCHAR           memory_pool[DEMO_BYTE_POOL_SIZE];
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -180,7 +180,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -219,7 +219,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -245,7 +245,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -272,7 +272,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -309,7 +309,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -334,7 +334,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a65_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a65_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a65_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a65_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a65ae_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a65ae_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a65ae_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a65ae_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a72_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a72_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a72_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a72_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a73_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a73_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a73_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a73_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a75_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a75_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a75_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a75_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a76_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a76_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a76_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a76_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a76ae_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a76ae_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a76ae_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a76ae_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a77_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a77_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a77_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a77_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a78_smp/ac6/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a78_smp/ac6/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a78_smp/gnu/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a78_smp/gnu/example_build/sample_threadx/sample_threadx.c
@@ -56,12 +56,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -198,7 +198,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -224,7 +224,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -250,7 +250,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -277,7 +277,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -314,7 +314,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -339,7 +339,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a7_smp/ac5/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a7_smp/ac5/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -184,7 +184,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -210,7 +210,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -236,7 +236,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -263,7 +263,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -300,7 +300,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -325,7 +325,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a7_smp/gnu/example_build/sample_threadx.c
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -184,7 +184,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -210,7 +210,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -236,7 +236,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -263,7 +263,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -300,7 +300,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -325,7 +325,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a9_smp/ac5/example_build/sample_threadx/sample_threadx.c
+++ b/ports_smp/cortex_a9_smp/ac5/example_build/sample_threadx/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -184,7 +184,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -210,7 +210,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -236,7 +236,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -263,7 +263,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -300,7 +300,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -325,7 +325,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_a9_smp/gnu/example_build/sample_threadx.c
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -184,7 +184,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -210,7 +210,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -236,7 +236,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -263,7 +263,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -300,7 +300,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -325,7 +325,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/cortex_r8_smp/ac5/example_build/sample_threadx/demo_threadx.c
+++ b/ports_smp/cortex_r8_smp/ac5/example_build/sample_threadx/demo_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 #ifdef TX_ENABLE_EVENT_TRACE
@@ -184,7 +184,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -210,7 +210,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -236,7 +236,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -263,7 +263,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -300,7 +300,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -325,7 +325,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/linux/gnu/example_build/sample_threadx.c
+++ b/ports_smp/linux/gnu/example_build/sample_threadx.c
@@ -45,12 +45,12 @@ ULONG           thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -174,7 +174,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -211,7 +211,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -237,7 +237,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -264,7 +264,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -301,7 +301,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -326,7 +326,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/ports_smp/mips32_interaptiv_smp/gnu/example_build/demo_threadx.c
+++ b/ports_smp/mips32_interaptiv_smp/gnu/example_build/demo_threadx.c
@@ -59,13 +59,13 @@ ULONG                   lcd_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
-void    lcd_thread_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
+void    lcd_thread_entry(ALIGN_TYPE thread_input);
 
 #ifdef TX_ENABLE_EVENT_TRACE
 
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -279,7 +279,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -307,7 +307,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -344,7 +344,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -369,7 +369,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -423,7 +423,7 @@ UINT    status;
 }
 
 
-void  lcd_thread_entry(ULONG thread_input)
+void  lcd_thread_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    state = 0;

--- a/ports_smp/mips32_interaptiv_smp/green/example_build/demo_threadx.c
+++ b/ports_smp/mips32_interaptiv_smp/green/example_build/demo_threadx.c
@@ -59,13 +59,13 @@ ULONG                   lcd_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
-void    lcd_thread_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
+void    lcd_thread_entry(ALIGN_TYPE thread_input);
 
 #ifdef TX_ENABLE_EVENT_TRACE
 
@@ -228,7 +228,7 @@ CHAR    *pointer;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -253,7 +253,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -279,7 +279,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -307,7 +307,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -344,7 +344,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -369,7 +369,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -423,7 +423,7 @@ UINT    status;
 }
 
 
-void  lcd_thread_entry(ULONG thread_input)
+void  lcd_thread_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    state = 0;

--- a/samples/demo_threadx.c
+++ b/samples/demo_threadx.c
@@ -45,12 +45,12 @@ ULONG                   thread_7_counter;
 
 /* Define thread prototypes.  */
 
-void    thread_0_entry(ULONG thread_input);
-void    thread_1_entry(ULONG thread_input);
-void    thread_2_entry(ULONG thread_input);
-void    thread_3_and_4_entry(ULONG thread_input);
-void    thread_5_entry(ULONG thread_input);
-void    thread_6_and_7_entry(ULONG thread_input);
+void    thread_0_entry(ALIGN_TYPE thread_input);
+void    thread_1_entry(ALIGN_TYPE thread_input);
+void    thread_2_entry(ALIGN_TYPE thread_input);
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input);
+void    thread_5_entry(ALIGN_TYPE thread_input);
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input);
 
 
 /* Define main entry point.  */
@@ -175,7 +175,7 @@ CHAR    *pointer = TX_NULL;
 
 /* Define the test threads.  */
 
-void    thread_0_entry(ULONG thread_input)
+void    thread_0_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -201,7 +201,7 @@ UINT    status;
 }
 
 
-void    thread_1_entry(ULONG thread_input)
+void    thread_1_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -227,7 +227,7 @@ UINT    status;
 }
 
 
-void    thread_2_entry(ULONG thread_input)
+void    thread_2_entry(ALIGN_TYPE thread_input)
 {
 
 ULONG   received_message;
@@ -254,7 +254,7 @@ UINT    status;
 }
 
 
-void    thread_3_and_4_entry(ULONG thread_input)
+void    thread_3_and_4_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -291,7 +291,7 @@ UINT    status;
 }
 
 
-void    thread_5_entry(ULONG thread_input)
+void    thread_5_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;
@@ -316,7 +316,7 @@ ULONG   actual_flags;
 }
 
 
-void    thread_6_and_7_entry(ULONG thread_input)
+void    thread_6_and_7_entry(ALIGN_TYPE thread_input)
 {
 
 UINT    status;

--- a/utility/benchmarks/thread_metric/threadx_example/tm_porting_layer_threadx.c
+++ b/utility/benchmarks/thread_metric/threadx_example/tm_porting_layer_threadx.c
@@ -108,7 +108,7 @@ void            (*tm_initialization_function)(void);
 
 /* Define our shell entry function to match ThreadX.  */
 
-VOID  tm_thread_entry(ULONG thread_input);
+VOID  tm_thread_entry(ALIGN_TYPE thread_input);
 
 
 /* This function called from main performs basic RTOS initialization, 
@@ -385,7 +385,7 @@ UINT    status;
 
 /* This is the ThreadX thread entry.  It is going to call the Thread-Metric
    entry function saved earlier.  */
-VOID  tm_thread_entry(ULONG thread_input)
+VOID  tm_thread_entry(ALIGN_TYPE thread_input)
 {
 
 void (*entry_function)(void);

--- a/utility/rtos_compatibility_layers/FreeRTOS/tx_freertos.c
+++ b/utility/rtos_compatibility_layers/FreeRTOS/tx_freertos.c
@@ -2248,7 +2248,7 @@ EventBits_t xEventGroupGetBitsFromISR(EventGroupHandle_t xEventGroup)
 }
 
 
-void txfr_timer_callback_wrapper(ULONG id)
+void txfr_timer_callback_wrapper(ALIGN_TYPE id)
 {
     txfr_timer_t *p_timer;
 
@@ -2300,7 +2300,7 @@ TimerHandle_t xTimerCreate(const char * const pcTimerName,
         resch_ticks = 0u;
     }
 
-    ret = tx_timer_create(&p_timer->timer, (char *)pcTimerName, txfr_timer_callback_wrapper, (ULONG)p_timer, xTimerPeriod, resch_ticks, TX_NO_ACTIVATE);
+    ret = tx_timer_create(&p_timer->timer, (char *)pcTimerName, txfr_timer_callback_wrapper, (ALIGN_TYPE)p_timer, xTimerPeriod, resch_ticks, TX_NO_ACTIVATE);
     if(ret != TX_SUCCESS) {
         txfr_free(p_timer);
         return NULL;
@@ -2341,7 +2341,7 @@ TimerHandle_t xTimerCreateStatic(const char * const pcTimerName,
         resch_ticks = 0u;
     }
 
-    ret = tx_timer_create(&pxTimerBuffer->timer, (char *)pcTimerName, txfr_timer_callback_wrapper, (ULONG)pxTimerBuffer, xTimerPeriod, resch_ticks, TX_NO_ACTIVATE);
+    ret = tx_timer_create(&pxTimerBuffer->timer, (char *)pcTimerName, txfr_timer_callback_wrapper, (ALIGN_TYPE)pxTimerBuffer, xTimerPeriod, resch_ticks, TX_NO_ACTIVATE);
     if(ret != TX_SUCCESS) {
         return NULL;
     }

--- a/utility/rtos_compatibility_layers/OSEK/demo_osek.c
+++ b/utility/rtos_compatibility_layers/OSEK/demo_osek.c
@@ -101,7 +101,7 @@ CHAR    * pointer;
     DemoISR = CreateISR("Demo ISR", ISREntry(DemoISR), CATEGORY2, 1024);
 
     /* Create a ThreadX timer to simulate an ISR.  */
-    tx_timer_create(&demo_isr_timer, "Demo ISR timer", demo_isr_timer_entry, DemoISR,
+    tx_timer_create(&demo_isr_timer, "Demo ISR timer", demo_isr_timer_entry, (ALIGN_TYPE)DemoISR,
                      1000, 1000, TX_AUTO_ACTIVATE);
     
     /* Start OSEK  */
@@ -150,7 +150,7 @@ static void ErrorHook(StatusType Error)
 }
 
 /* ThreadX timer handler to simulate an ISR.  */
-VOID demo_isr_timer_entry(ULONG arg)
+VOID demo_isr_timer_entry(ALIGN_TYPE arg)
 {
     /* Call OSEK to process the ISR.  */
     process_ISR2(arg);

--- a/utility/rtos_compatibility_layers/OSEK/tx_osek.c
+++ b/utility/rtos_compatibility_layers/OSEK/tx_osek.c
@@ -1222,7 +1222,7 @@ TX_THREAD      *p_thread;
 /*    GetTaskID returns the task id of the task currently running.        */
 /*    Calling GetTaskID is allowed from task level, ISR level and in      */
 /*    several hook routines. This service is intended to be used by       */
-/*    library functions and hook routines. If <TaskID> can’t be evaluated */
+/*    library functions and hook routines. If <TaskID> canï¿½t be evaluated */
 /*    (no task currently running), the service returns INVALID_TASK as    */
 /*    TaskType.                                                           */
 /*                                                                        */
@@ -1268,7 +1268,7 @@ TX_THREAD      *thread_ptr;
 
    if ((thread_ptr == TX_NULL) || (thread_ptr == &_tx_timer_thread))
    {
-       /* No task running TaskID can’t be evaluated return a special Error.  */
+       /* No task running TaskID canï¿½t be evaluated return a special Error.  */
        *TaskID = INVALID_TASK;
 
        return (E_OK);
@@ -7798,7 +7798,7 @@ UINT               index;
 /*  06-02-2021     William E. Lamie         Initial Version 6.1.7         */
 /*                                                                        */
 /**************************************************************************/
-static void osek_system_timer_entry(ULONG input)
+static void osek_system_timer_entry(ALIGN_TYPE input)
 {
 TX_INTERRUPT_SAVE_AREA
 OSEK_COUNTER      *this_counter;


### PR DESCRIPTION
These functions have an ULONG type param, so if you want to pass a pointer to something you can cast it and it will fit in the ULONG param in 32 bit machines. But in 64 bit machines the pointer will not fit, so I propose to change this param to ALIGN_TYPE type.

For example, the following code will work in 32 bit machines, but it will not work on 64 bit machines:

```
struct my_object_type;

void my_thread_example_entry(ULONG param)
{
struct my_object_type *obj = (struct my_object_type *)param;
. . . 
}

void    tx_application_define(void *first_unused_memory)
{
 . . . 
tx_thread_create(&thread_1, "thread 1", my_thread_example_entry, (ULONG)&my_object,  
            stack_start, STACK_SIZE, 16, 16, 4, TX_AUTO_START);

. . . 
}
```

With the changes proposed, the code will turn into:

```
struct my_object_type;

void my_thread_example_entry(ALIGN_TYPE param)
{
struct my_object_type *obj = (struct my_object_type *)param;
. . . 
}

void    tx_application_define(void *first_unused_memory)
{
 . . . 
tx_thread_create(&thread_1, "thread 1", my_thread_example_entry, (ALIGN_TYPE )&my_object,  
            stack_start, STACK_SIZE, 16, 16, 4, TX_AUTO_START);

. . . 
}
```
And it will work ok both in 32 and 64 bit systems.
