### PR TITLE
SysTick initialization problem fixed in tx_initialize_low_level.s

### DIFF
--- a/ports/cortex_m0/ac5/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m0/ac5/example_build/tx_initialize_low_level.s
@@ -176,6 +176,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick.  */
 ;
     LDR     r0, =0xE000E000                         ; Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOVS    r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m0/ac5/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m0/ac5/example_build/tx_initialize_low_level.s
@@ -177,8 +177,8 @@ _tx_initialize_low_level
 ;
     LDR     r0, =0xE000E000                         ; Build address of NVIC registers
     LDR     r1, =0
-    STR     r1, [r0, #0x10]                         // Reset SysTick Control
-    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOVS    r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m0/gnu/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m0/gnu/example_build/tx_initialize_low_level.S
@@ -134,6 +134,9 @@ _tx_initialize_low_level:
 @    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 @
     LDR     r0, =0xE000E000                         @ Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     LDR     r1, =0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m0/iar/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m0/iar/example_build/tx_initialize_low_level.s
@@ -125,6 +125,9 @@ _tx_initialize_low_level:
 ;    /* Configure SysTick.  */
 ;
     LDR     r0, =0xE000E000                         ; Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOVS    r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m0/iar/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m0/iar/example_build/tx_initialize_low_level.s
@@ -126,8 +126,8 @@ _tx_initialize_low_level:
 ;
     LDR     r0, =0xE000E000                         ; Build address of NVIC registers
     LDR     r1, =0
-    STR     r1, [r0, #0x10]                         // Reset SysTick Control
-    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOVS    r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m0/keil/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m0/keil/example_build/tx_initialize_low_level.s
@@ -176,6 +176,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick.  */
 ;
     LDR     r0, =0xE000E000                         ; Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOVS    r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m0/keil/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m0/keil/example_build/tx_initialize_low_level.s
@@ -177,8 +177,8 @@ _tx_initialize_low_level
 ;
     LDR     r0, =0xE000E000                         ; Build address of NVIC registers
     LDR     r1, =0
-    STR     r1, [r0, #0x10]                         // Reset SysTick Control
-    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOVS    r1, #0x7                                ; Build SysTick Control Enable Value


### PR DESCRIPTION
Problem with first system tick was detected, it needs much more time for the first tick as it's defined. The reason for this behavior is incorrect initialization of the SysTick timer in the port file for the Cortex-M0. It doesn't reset the SysTick Current Value Register despite the fact that its value is not initialized at startup (see https://developer.arm.com/documentation/dui0552/a/cortex-m3-peripherals/system-timer--systick). So if we have 0xFFFFFF (this register has 24-bit), it means we will get about 256*256*256 / 48000000 for the tact frequency of 48MHz to reach the zero, that makes 350ms delay at startup, which is what was observed on a real microcontroller.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [x] Validated on real hardware <!-- ATSAMC21E - GCC -->