### PR TITLE
Fixed a typo in tx_api.h

### DIFF
--- a/common_smp/inc/tx_api.h
+++ b/common_smp/inc/tx_api.h
@@ -130,7 +130,7 @@ extern   "C" {
 #ifndef TX_BYTE_POOL_MULTIPLE_BLOCK_SEARCH
 #define TX_BYTE_POOL_MULTIPLE_BLOCK_SEARCH    20
 #endif
-#ifndef TX_BTYE_POOL_DELAY_VALUE
+#ifndef TX_BYTE_POOL_DELAY_VALUE
 #define TX_BYTE_POOL_DELAY_VALUE              3
 #endif
 


### PR DESCRIPTION
Fixed a typo on line 123 in tx-api.h:
was: TX_BTYE_POOL_DELAY_VALUE
now: TX_BYTE_POOL_DELAY_VALUE

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [ ] Validated on real hardware <!-- hardware - toolchain -->