### PR TITLE
Fix the issue of byte pool alloc fail when compile with -O3 optimization

### DIFF
--- a/common/inc/tx_byte_pool.h
+++ b/common/inc/tx_byte_pool.h
@@ -101,7 +101,7 @@ VOID        _tx_byte_pool_initialize(VOID);
 
 /* Define internal byte memory pool management function prototypes.  */
 
-UCHAR       *_tx_byte_pool_search(TX_BYTE_POOL *pool_ptr, ULONG memory_size);
+UCHAR       *_tx_byte_pool_search(volatile TX_BYTE_POOL *pool_ptr, ULONG memory_size);
 VOID        _tx_byte_pool_cleanup(TX_THREAD *thread_ptr, ULONG suspension_sequence);
 
 

--- a/common/src/tx_byte_pool_search.c
+++ b/common/src/tx_byte_pool_search.c
@@ -83,7 +83,7 @@
 /*                                            resulting in version 6.1.7  */
 /*                                                                        */
 /**************************************************************************/
-UCHAR  *_tx_byte_pool_search(TX_BYTE_POOL *pool_ptr, ULONG memory_size)
+UCHAR  *_tx_byte_pool_search(volatile TX_BYTE_POOL *pool_ptr, ULONG memory_size)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/inc/tx_byte_pool.h
+++ b/common_smp/inc/tx_byte_pool.h
@@ -101,7 +101,7 @@ VOID        _tx_byte_pool_initialize(VOID);
 
 /* Define internal byte memory pool management function prototypes.  */
 
-UCHAR       *_tx_byte_pool_search(TX_BYTE_POOL *pool_ptr, ULONG memory_size);
+UCHAR       *_tx_byte_pool_search(volatile TX_BYTE_POOL *pool_ptr, ULONG memory_size);
 VOID        _tx_byte_pool_cleanup(TX_THREAD *thread_ptr, ULONG suspension_sequence);
 
 

--- a/common_smp/src/tx_byte_pool_search.c
+++ b/common_smp/src/tx_byte_pool_search.c
@@ -84,7 +84,7 @@
 /*                                            resulting in version 6.3.0  */
 /*                                                                        */
 /**************************************************************************/
-UCHAR  *_tx_byte_pool_search(TX_BYTE_POOL *pool_ptr, ULONG memory_size)
+UCHAR  *_tx_byte_pool_search(volatile TX_BYTE_POOL *pool_ptr, ULONG memory_size)
 {
 
 TX_INTERRUPT_SAVE_AREA


### PR DESCRIPTION
https://github.com/eclipse-threadx/threadx/issues/334

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] Updated function header with a short description and version number
- [x] Added test case for bug fix or new feature
- [x] Validated on real hardware <!-- hardware - toolchain -->