### PR TITLE
Add option for target_compile_options and definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ target_include_directories(${PROJECT_NAME}
     ${CUSTOM_INC_DIR}
 )
 target_compile_definitions(${PROJECT_NAME} PUBLIC "TX_INCLUDE_USER_DEFINE_FILE" )
+target_compile_options(${PROJECT_NAME} PUBLIC ${THREADX_COMPILE_FLAGS})
 
 # Enable a build target that produces a ZIP file of all sources
 set(CPACK_SOURCE_GENERATOR "ZIP")


### PR DESCRIPTION
Add option to include custom compile options for threadx library.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] Updated function header with a short description and version number
- [x] Added test case for bug fix or new feature
- [x] Validated on real hardware <!-- hardware - toolchain -->