### PR TITLE
Add target_compile_definitions and options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,8 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC 
     ${CUSTOM_INC_DIR}
 )
-target_compile_definitions(${PROJECT_NAME} PUBLIC "TX_INCLUDE_USER_DEFINE_FILE" )
+target_compile_definitions(${PROJECT_NAME} PUBLIC "TX_INCLUDE_USER_DEFINE_FILE" ${THREADX_COMPILE_DEFINITIONS} )
+target_compile_options(${PROJECT_NAME} PUBLIC ${THREADX_COMPILE_OPTIONS} )
 
 # Enable a build target that produces a ZIP file of all sources
 set(CPACK_SOURCE_GENERATOR "ZIP")


### PR DESCRIPTION
Add variables to let user enter custom compiler options and definitions during integration process.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] Updated function header with a short description and version number
- [x] Added test case for bug fix or new feature
- [x] Validated on real hardware <!-- hardware - toolchain -->