### PR TITLE
Add new label for all created issues, enforce the use of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve Eclipse ThreadX.
 title: ''
-labels: bug, hardware
+labels: new, bug, hardware
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea or enhancement to existing feature for Eclipse ThreadX.
 title: ''
-labels: ["feature", "new"]
+labels: new, feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea or enhancement to existing feature for Eclipse ThreadX.
 title: ''
-labels: feature
+labels: ["feature", "new"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/hardware-or-architecture-support.md
+++ b/.github/ISSUE_TEMPLATE/hardware-or-architecture-support.md
@@ -2,7 +2,7 @@
 name: Hardware or architecture support
 about: Suggest adding hardware or new architecture support.
 title: ''
-labels: ''
+labels: new
 assignees: ''
 
 ---


### PR DESCRIPTION
As requested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4667#note_2337435