### PR TITLE
const: Add const keyword for all name pointer parameters

### DIFF
--- a/common/inc/tx_api.h
+++ b/common/inc/tx_api.h
@@ -428,7 +428,7 @@ typedef struct TX_TIMER_STRUCT
     ULONG               tx_timer_id;
 
     /* Define the timer's name.  */
-    CHAR                *tx_timer_name;
+    const CHAR          *tx_timer_name;
 
     /* Define the actual contents of the timer.  This is the block that
        is used in the actual timer expiration processing.  */
@@ -494,7 +494,7 @@ typedef struct TX_THREAD_STRUCT
        is typically defined to whitespace or a pointer type in tx_port.h.  */
     TX_THREAD_EXTENSION_0
 
-    CHAR                *tx_thread_name;                /* Pointer to thread's name     */
+    const CHAR          *tx_thread_name;                /* Pointer to thread's name     */
     UINT                tx_thread_priority;             /* Priority of thread (0-1023)  */
     UINT                tx_thread_state;                /* Thread's execution state     */
     UINT                tx_thread_delayed_suspend;      /* Delayed suspend flag         */
@@ -655,7 +655,7 @@ typedef struct TX_BLOCK_POOL_STRUCT
     ULONG               tx_block_pool_id;
 
     /* Define the block pool's name.  */
-    CHAR                *tx_block_pool_name;
+    const CHAR          *tx_block_pool_name;
 
     /* Define the number of available memory blocks in the pool.  */
     UINT                tx_block_pool_available;
@@ -733,7 +733,7 @@ typedef struct TX_BYTE_POOL_STRUCT
     ULONG               tx_byte_pool_id;
 
     /* Define the byte pool's name.  */
-    CHAR                *tx_byte_pool_name;
+    const CHAR          *tx_byte_pool_name;
 
     /* Define the number of available bytes in the pool.  */
     ULONG               tx_byte_pool_available;
@@ -812,7 +812,7 @@ typedef struct TX_EVENT_FLAGS_GROUP_STRUCT
     ULONG               tx_event_flags_group_id;
 
     /* Define the event flags group's name.  */
-    CHAR                *tx_event_flags_group_name;
+    const CHAR          *tx_event_flags_group_name;
 
     /* Define the actual current event flags in this group. A zero in a
        particular bit indicates the event flag is not set.  */
@@ -898,7 +898,7 @@ typedef struct TX_MUTEX_STRUCT
     ULONG               tx_mutex_id;
 
     /* Define the mutex's name.  */
-    CHAR                *tx_mutex_name;
+    const CHAR          *tx_mutex_name;
 
     /* Define the mutex ownership count.  */
     UINT                tx_mutex_ownership_count;
@@ -971,7 +971,7 @@ typedef struct TX_QUEUE_STRUCT
     ULONG               tx_queue_id;
 
     /* Define the queue's name.  */
-    CHAR                *tx_queue_name;
+    const CHAR          *tx_queue_name;
 
     /* Define the message size that was specified in queue creation.  */
     UINT                tx_queue_message_size;
@@ -1050,7 +1050,7 @@ typedef struct TX_SEMAPHORE_STRUCT
     ULONG               tx_semaphore_id;
 
     /* Define the semaphore's name.  */
-    CHAR                *tx_semaphore_name;
+    const CHAR          *tx_semaphore_name;
 
     /* Define the actual semaphore count.  A zero means that no semaphore
        instance is available.  */
@@ -1477,7 +1477,7 @@ VOID        tx_application_define(VOID *first_unused_memory);
 /* Define block memory pool management function prototypes.  */
 
 UINT        _tx_block_allocate(TX_BLOCK_POOL *pool_ptr, VOID **block_ptr, ULONG wait_option);
-UINT        _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT        _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size);
 UINT        _tx_block_pool_delete(TX_BLOCK_POOL *pool_ptr);
 UINT        _tx_block_pool_info_get(TX_BLOCK_POOL *pool_ptr, CHAR **name, ULONG *available_blocks,
@@ -1495,7 +1495,7 @@ UINT        _tx_block_release(VOID *block_ptr);
    application.  */
 
 UINT        _txe_block_allocate(TX_BLOCK_POOL *pool_ptr, VOID **block_ptr, ULONG wait_option);
-UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size, UINT pool_control_block_size);
 UINT        _txe_block_pool_delete(TX_BLOCK_POOL *pool_ptr);
 UINT        _txe_block_pool_info_get(TX_BLOCK_POOL *pool_ptr, CHAR **name, ULONG *available_blocks,
@@ -1505,7 +1505,7 @@ UINT        _txe_block_pool_prioritize(TX_BLOCK_POOL *pool_ptr);
 UINT        _txe_block_release(VOID *block_ptr);
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
 UINT        _txr_block_allocate(TX_BLOCK_POOL *pool_ptr, VOID **block_ptr, ULONG wait_option);
-UINT        _txr_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT        _txr_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size, UINT pool_control_block_size);
 UINT        _txr_block_pool_delete(TX_BLOCK_POOL *pool_ptr);
 UINT        _txr_block_pool_info_get(TX_BLOCK_POOL *pool_ptr, CHAR **name, ULONG *available_blocks,
@@ -1520,7 +1520,7 @@ UINT        _txr_block_release(VOID *block_ptr);
 
 UINT        _tx_byte_allocate(TX_BYTE_POOL *pool_ptr, VOID **memory_ptr, ULONG memory_size,
                     ULONG wait_option);
-UINT        _tx_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start,
+UINT        _tx_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start,
                     ULONG pool_size);
 UINT        _tx_byte_pool_delete(TX_BYTE_POOL *pool_ptr);
 UINT        _tx_byte_pool_info_get(TX_BYTE_POOL *pool_ptr, CHAR **name, ULONG *available_bytes,
@@ -1539,7 +1539,7 @@ UINT        _tx_byte_release(VOID *memory_ptr);
 
 UINT        _txe_byte_allocate(TX_BYTE_POOL *pool_ptr, VOID **memory_ptr, ULONG memory_size,
                     ULONG wait_option);
-UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start,
+UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start,
                     ULONG pool_size, UINT pool_control_block_size);
 UINT        _txe_byte_pool_delete(TX_BYTE_POOL *pool_ptr);
 UINT        _txe_byte_pool_info_get(TX_BYTE_POOL *pool_ptr, CHAR **name, ULONG *available_bytes,
@@ -1550,7 +1550,7 @@ UINT        _txe_byte_release(VOID *memory_ptr);
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
 UINT        _txr_byte_allocate(TX_BYTE_POOL *pool_ptr, VOID **memory_ptr, ULONG memory_size,
                     ULONG wait_option);
-UINT        _txr_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start,
+UINT        _txr_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start,
                     ULONG pool_size, UINT pool_control_block_size);
 UINT        _txr_byte_pool_delete(TX_BYTE_POOL *pool_ptr);
 UINT        _txr_byte_pool_info_get(TX_BYTE_POOL *pool_ptr, CHAR **name, ULONG *available_bytes,
@@ -1563,7 +1563,7 @@ UINT        _txr_byte_release(VOID *memory_ptr);
 
 /* Define event flags management function prototypes.  */
 
-UINT        _tx_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr);
+UINT        _tx_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr);
 UINT        _tx_event_flags_delete(TX_EVENT_FLAGS_GROUP *group_ptr);
 UINT        _tx_event_flags_get(TX_EVENT_FLAGS_GROUP *group_ptr, ULONG requested_flags,
                     UINT get_option, ULONG *actual_flags_ptr, ULONG wait_option);
@@ -1582,7 +1582,7 @@ UINT        _tx_event_flags_set_notify(TX_EVENT_FLAGS_GROUP *group_ptr, VOID (*e
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr, UINT event_control_block_size);
+UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr, UINT event_control_block_size);
 UINT        _txe_event_flags_delete(TX_EVENT_FLAGS_GROUP *group_ptr);
 UINT        _txe_event_flags_get(TX_EVENT_FLAGS_GROUP *group_ptr, ULONG requested_flags,
                     UINT get_option, ULONG *actual_flags_ptr, ULONG wait_option);
@@ -1593,7 +1593,7 @@ UINT        _txe_event_flags_set(TX_EVENT_FLAGS_GROUP *group_ptr, ULONG flags_to
                     UINT set_option);
 UINT        _txe_event_flags_set_notify(TX_EVENT_FLAGS_GROUP *group_ptr, VOID (*events_set_notify)(TX_EVENT_FLAGS_GROUP *notify_group_ptr));
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
-UINT        _txr_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr, UINT event_control_block_size);
+UINT        _txr_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr, UINT event_control_block_size);
 UINT        _txr_event_flags_delete(TX_EVENT_FLAGS_GROUP *group_ptr);
 UINT        _txr_event_flags_get(TX_EVENT_FLAGS_GROUP *group_ptr, ULONG requested_flags,
                     UINT get_option, ULONG *actual_flags_ptr, ULONG wait_option);
@@ -1613,7 +1613,7 @@ VOID        _tx_initialize_kernel_enter(VOID);
 
 /* Define mutex management function prototypes.  */
 
-UINT        _tx_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit);
+UINT        _tx_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit);
 UINT        _tx_mutex_delete(TX_MUTEX *mutex_ptr);
 UINT        _tx_mutex_get(TX_MUTEX *mutex_ptr, ULONG wait_option);
 UINT        _tx_mutex_info_get(TX_MUTEX *mutex_ptr, CHAR **name, ULONG *count, TX_THREAD **owner,
@@ -1630,7 +1630,7 @@ UINT        _tx_mutex_put(TX_MUTEX *mutex_ptr);
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
+UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
 UINT        _txe_mutex_delete(TX_MUTEX *mutex_ptr);
 UINT        _txe_mutex_get(TX_MUTEX *mutex_ptr, ULONG wait_option);
 UINT        _txe_mutex_info_get(TX_MUTEX *mutex_ptr, CHAR **name, ULONG *count, TX_THREAD **owner,
@@ -1639,7 +1639,7 @@ UINT        _txe_mutex_info_get(TX_MUTEX *mutex_ptr, CHAR **name, ULONG *count, 
 UINT        _txe_mutex_prioritize(TX_MUTEX *mutex_ptr);
 UINT        _txe_mutex_put(TX_MUTEX *mutex_ptr);
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
-UINT        _txr_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
+UINT        _txr_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
 UINT        _txr_mutex_delete(TX_MUTEX *mutex_ptr);
 UINT        _txr_mutex_get(TX_MUTEX *mutex_ptr, ULONG wait_option);
 UINT        _txr_mutex_info_get(TX_MUTEX *mutex_ptr, CHAR **name, ULONG *count, TX_THREAD **owner,
@@ -1652,7 +1652,7 @@ UINT        _txr_mutex_put(TX_MUTEX *mutex_ptr);
 
 /* Define queue management function prototypes.  */
 
-UINT        _tx_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size,
+UINT        _tx_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size,
                         VOID *queue_start, ULONG queue_size);
 UINT        _tx_queue_delete(TX_QUEUE *queue_ptr);
 UINT        _tx_queue_flush(TX_QUEUE *queue_ptr);
@@ -1672,7 +1672,7 @@ UINT        _tx_queue_front_send(TX_QUEUE *queue_ptr, VOID *source_ptr, ULONG wa
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size,
+UINT        _txe_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size,
                         VOID *queue_start, ULONG queue_size, UINT queue_control_block_size);
 UINT        _txe_queue_delete(TX_QUEUE *queue_ptr);
 UINT        _txe_queue_flush(TX_QUEUE *queue_ptr);
@@ -1684,7 +1684,7 @@ UINT        _txe_queue_send(TX_QUEUE *queue_ptr, VOID *source_ptr, ULONG wait_op
 UINT        _txe_queue_send_notify(TX_QUEUE *queue_ptr, VOID (*queue_send_notify)(TX_QUEUE *notify_queue_ptr));
 UINT        _txe_queue_front_send(TX_QUEUE *queue_ptr, VOID *source_ptr, ULONG wait_option);
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
-UINT        _txr_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size,
+UINT        _txr_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size,
                         VOID *queue_start, ULONG queue_size, UINT queue_control_block_size);
 UINT        _txr_queue_delete(TX_QUEUE *queue_ptr);
 UINT        _txr_queue_flush(TX_QUEUE *queue_ptr);
@@ -1701,7 +1701,7 @@ UINT        _txr_queue_front_send(TX_QUEUE *queue_ptr, VOID *source_ptr, ULONG w
 /* Define semaphore management function prototypes.  */
 
 UINT        _tx_semaphore_ceiling_put(TX_SEMAPHORE *semaphore_ptr, ULONG ceiling);
-UINT        _tx_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count);
+UINT        _tx_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count);
 UINT        _tx_semaphore_delete(TX_SEMAPHORE *semaphore_ptr);
 UINT        _tx_semaphore_get(TX_SEMAPHORE *semaphore_ptr, ULONG wait_option);
 UINT        _tx_semaphore_info_get(TX_SEMAPHORE *semaphore_ptr, CHAR **name, ULONG *current_value,
@@ -1719,7 +1719,7 @@ UINT        _tx_semaphore_put_notify(TX_SEMAPHORE *semaphore_ptr, VOID (*semapho
    application.  */
 
 UINT        _txe_semaphore_ceiling_put(TX_SEMAPHORE *semaphore_ptr, ULONG ceiling);
-UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
+UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
 UINT        _txe_semaphore_delete(TX_SEMAPHORE *semaphore_ptr);
 UINT        _txe_semaphore_get(TX_SEMAPHORE *semaphore_ptr, ULONG wait_option);
 UINT        _txe_semaphore_info_get(TX_SEMAPHORE *semaphore_ptr, CHAR **name, ULONG *current_value,
@@ -1730,7 +1730,7 @@ UINT        _txe_semaphore_put(TX_SEMAPHORE *semaphore_ptr);
 UINT        _txe_semaphore_put_notify(TX_SEMAPHORE *semaphore_ptr, VOID (*semaphore_put_notify)(TX_SEMAPHORE *notify_semaphore_ptr));
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
 UINT        _txr_semaphore_ceiling_put(TX_SEMAPHORE *semaphore_ptr, ULONG ceiling);
-UINT        _txr_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
+UINT        _txr_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
 UINT        _txr_semaphore_delete(TX_SEMAPHORE *semaphore_ptr);
 UINT        _txr_semaphore_get(TX_SEMAPHORE *semaphore_ptr, ULONG wait_option);
 UINT        _txr_semaphore_info_get(TX_SEMAPHORE *semaphore_ptr, CHAR **name, ULONG *current_value,
@@ -1746,7 +1746,7 @@ UINT        _txr_semaphore_put_notify(TX_SEMAPHORE *semaphore_ptr, VOID (*semaph
 
 VOID        _tx_thread_context_save(VOID);
 VOID        _tx_thread_context_restore(VOID);
-UINT        _tx_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
+UINT        _tx_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr,
                 VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
@@ -1783,7 +1783,7 @@ UINT        _tx_thread_wait_abort(TX_THREAD *thread_ptr);
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
+UINT        _txe_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr,
                 VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
@@ -1805,7 +1805,7 @@ UINT        _txe_thread_terminate(TX_THREAD *thread_ptr);
 UINT        _txe_thread_time_slice_change(TX_THREAD *thread_ptr, ULONG new_time_slice, ULONG *old_time_slice);
 UINT        _txe_thread_wait_abort(TX_THREAD *thread_ptr);
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
-UINT        _txr_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
+UINT        _txr_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr,
                 VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
@@ -1832,7 +1832,7 @@ UINT        _txr_thread_wait_abort(TX_THREAD *thread_ptr);
 
 UINT        _tx_timer_activate(TX_TIMER *timer_ptr);
 UINT        _tx_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
-UINT        _tx_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
+UINT        _tx_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr,
                 VOID (*expiration_function)(ULONG input), ULONG expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate);
 UINT        _tx_timer_deactivate(TX_TIMER *timer_ptr);
@@ -1853,7 +1853,7 @@ VOID        _tx_time_set(ULONG new_time);
 
 UINT        _txe_timer_activate(TX_TIMER *timer_ptr);
 UINT        _txe_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
-UINT        _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
+UINT        _txe_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr,
                 VOID (*expiration_function)(ULONG input), ULONG expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 UINT        _txe_timer_deactivate(TX_TIMER *timer_ptr);
@@ -1863,7 +1863,7 @@ UINT        _txe_timer_info_get(TX_TIMER *timer_ptr, CHAR **name, UINT *active, 
 #ifdef TX_ENABLE_MULTI_ERROR_CHECKING
 UINT        _txr_timer_activate(TX_TIMER *timer_ptr);
 UINT        _txr_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
-UINT        _txr_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
+UINT        _txr_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr,
                 VOID (*expiration_function)(ULONG input), ULONG expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 UINT        _txr_timer_deactivate(TX_TIMER *timer_ptr);

--- a/common_modules/module_manager/src/txm_module_manager_object_pointer_get.c
+++ b/common_modules/module_manager/src/txm_module_manager_object_pointer_get.c
@@ -78,7 +78,7 @@
 /*  09-30-2020      Scott Larson            Initial Version 6.1           */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txm_module_manager_object_pointer_get(UINT object_type, CHAR *name, VOID **object_ptr)
+UINT  _txm_module_manager_object_pointer_get(UINT object_type, const CHAR *name, VOID **object_ptr)
 {
 
 UINT    status;

--- a/common_modules/module_manager/src/txm_module_manager_thread_create.c
+++ b/common_modules/module_manager/src/txm_module_manager_thread_create.c
@@ -101,7 +101,7 @@
 /*                                            resulting in version 6.3.0  */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txm_module_manager_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
+UINT  _txm_module_manager_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr,
                             VOID (*shell_function)(TX_THREAD *, TXM_MODULE_INSTANCE *),
                             VOID (*entry_function)(ULONG id), ULONG entry_input,
                             VOID *stack_start, ULONG stack_size, UINT priority, UINT preempt_threshold,

--- a/common_smp/inc/tx_api.h
+++ b/common_smp/inc/tx_api.h
@@ -1574,7 +1574,7 @@ VOID        tx_application_define(VOID *first_unused_memory);
 /* Define block memory pool management function prototypes.  */
 
 UINT        _tx_block_allocate(TX_BLOCK_POOL *pool_ptr, VOID **block_ptr, ULONG wait_option);
-UINT        _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT        _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size);
 UINT        _tx_block_pool_delete(TX_BLOCK_POOL *pool_ptr);
 UINT        _tx_block_pool_info_get(TX_BLOCK_POOL *pool_ptr, CHAR **name, ULONG *available_blocks,
@@ -1592,7 +1592,7 @@ UINT        _tx_block_release(VOID *block_ptr);
    application.  */
 
 UINT        _txe_block_allocate(TX_BLOCK_POOL *pool_ptr, VOID **block_ptr, ULONG wait_option);
-UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size, UINT pool_control_block_size);
 UINT        _txe_block_pool_delete(TX_BLOCK_POOL *pool_ptr);
 UINT        _txe_block_pool_info_get(TX_BLOCK_POOL *pool_ptr, CHAR **name, ULONG *available_blocks,
@@ -1606,7 +1606,7 @@ UINT        _txe_block_release(VOID *block_ptr);
 
 UINT        _tx_byte_allocate(TX_BYTE_POOL *pool_ptr, VOID **memory_ptr, ULONG memory_size,
                     ULONG wait_option);
-UINT        _tx_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start,
+UINT        _tx_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start,
                     ULONG pool_size);
 UINT        _tx_byte_pool_delete(TX_BYTE_POOL *pool_ptr);
 UINT        _tx_byte_pool_info_get(TX_BYTE_POOL *pool_ptr, CHAR **name, ULONG *available_bytes,
@@ -1625,7 +1625,7 @@ UINT        _tx_byte_release(VOID *memory_ptr);
 
 UINT        _txe_byte_allocate(TX_BYTE_POOL *pool_ptr, VOID **memory_ptr, ULONG memory_size,
                     ULONG wait_option);
-UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start,
+UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start,
                     ULONG pool_size, UINT pool_control_block_size);
 UINT        _txe_byte_pool_delete(TX_BYTE_POOL *pool_ptr);
 UINT        _txe_byte_pool_info_get(TX_BYTE_POOL *pool_ptr, CHAR **name, ULONG *available_bytes,
@@ -1637,7 +1637,7 @@ UINT        _txe_byte_release(VOID *memory_ptr);
 
 /* Define event flags management function prototypes.  */
 
-UINT        _tx_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr);
+UINT        _tx_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr);
 UINT        _tx_event_flags_delete(TX_EVENT_FLAGS_GROUP *group_ptr);
 UINT        _tx_event_flags_get(TX_EVENT_FLAGS_GROUP *group_ptr, ULONG requested_flags,
                     UINT get_option, ULONG *actual_flags_ptr, ULONG wait_option);
@@ -1656,7 +1656,7 @@ UINT        _tx_event_flags_set_notify(TX_EVENT_FLAGS_GROUP *group_ptr, VOID (*e
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr, UINT event_control_block_size);
+UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr, UINT event_control_block_size);
 UINT        _txe_event_flags_delete(TX_EVENT_FLAGS_GROUP *group_ptr);
 UINT        _txe_event_flags_get(TX_EVENT_FLAGS_GROUP *group_ptr, ULONG requested_flags,
                     UINT get_option, ULONG *actual_flags_ptr, ULONG wait_option);
@@ -1675,7 +1675,7 @@ VOID        _tx_initialize_kernel_enter(VOID);
 
 /* Define mutex management function prototypes.  */
 
-UINT        _tx_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit);
+UINT        _tx_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit);
 UINT        _tx_mutex_delete(TX_MUTEX *mutex_ptr);
 UINT        _tx_mutex_get(TX_MUTEX *mutex_ptr, ULONG wait_option);
 UINT        _tx_mutex_info_get(TX_MUTEX *mutex_ptr, CHAR **name, ULONG *count, TX_THREAD **owner,
@@ -1692,7 +1692,7 @@ UINT        _tx_mutex_put(TX_MUTEX *mutex_ptr);
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
+UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
 UINT        _txe_mutex_delete(TX_MUTEX *mutex_ptr);
 UINT        _txe_mutex_get(TX_MUTEX *mutex_ptr, ULONG wait_option);
 UINT        _txe_mutex_info_get(TX_MUTEX *mutex_ptr, CHAR **name, ULONG *count, TX_THREAD **owner,
@@ -1704,7 +1704,7 @@ UINT        _txe_mutex_put(TX_MUTEX *mutex_ptr);
 
 /* Define queue management function prototypes.  */
 
-UINT        _tx_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size,
+UINT        _tx_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size,
                         VOID *queue_start, ULONG queue_size);
 UINT        _tx_queue_delete(TX_QUEUE *queue_ptr);
 UINT        _tx_queue_flush(TX_QUEUE *queue_ptr);
@@ -1724,7 +1724,7 @@ UINT        _tx_queue_front_send(TX_QUEUE *queue_ptr, VOID *source_ptr, ULONG wa
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size,
+UINT        _txe_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size,
                         VOID *queue_start, ULONG queue_size, UINT queue_control_block_size);
 UINT        _txe_queue_delete(TX_QUEUE *queue_ptr);
 UINT        _txe_queue_flush(TX_QUEUE *queue_ptr);
@@ -1740,7 +1740,7 @@ UINT        _txe_queue_front_send(TX_QUEUE *queue_ptr, VOID *source_ptr, ULONG w
 /* Define semaphore management function prototypes.  */
 
 UINT        _tx_semaphore_ceiling_put(TX_SEMAPHORE *semaphore_ptr, ULONG ceiling);
-UINT        _tx_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count);
+UINT        _tx_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count);
 UINT        _tx_semaphore_delete(TX_SEMAPHORE *semaphore_ptr);
 UINT        _tx_semaphore_get(TX_SEMAPHORE *semaphore_ptr, ULONG wait_option);
 UINT        _tx_semaphore_info_get(TX_SEMAPHORE *semaphore_ptr, CHAR **name, ULONG *current_value,
@@ -1758,7 +1758,7 @@ UINT        _tx_semaphore_put_notify(TX_SEMAPHORE *semaphore_ptr, VOID (*semapho
    application.  */
 
 UINT        _txe_semaphore_ceiling_put(TX_SEMAPHORE *semaphore_ptr, ULONG ceiling);
-UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
+UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
 UINT        _txe_semaphore_delete(TX_SEMAPHORE *semaphore_ptr);
 UINT        _txe_semaphore_get(TX_SEMAPHORE *semaphore_ptr, ULONG wait_option);
 UINT        _txe_semaphore_info_get(TX_SEMAPHORE *semaphore_ptr, CHAR **name, ULONG *current_value,
@@ -1773,7 +1773,7 @@ UINT        _txe_semaphore_put_notify(TX_SEMAPHORE *semaphore_ptr, VOID (*semaph
 
 VOID        _tx_thread_context_save(VOID);
 VOID        _tx_thread_context_restore(VOID);
-UINT        _tx_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
+UINT        _tx_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr,
                 VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
@@ -1810,7 +1810,7 @@ UINT        _tx_thread_wait_abort(TX_THREAD *thread_ptr);
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */
 
-UINT        _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
+UINT        _txe_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr,
                 VOID (*entry_function)(ULONG entry_input), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,
@@ -1837,7 +1837,7 @@ UINT        _txe_thread_wait_abort(TX_THREAD *thread_ptr);
 
 UINT        _tx_timer_activate(TX_TIMER *timer_ptr);
 UINT        _tx_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
-UINT        _tx_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
+UINT        _tx_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr,
                 VOID (*expiration_function)(ULONG input), ULONG expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate);
 UINT        _tx_timer_deactivate(TX_TIMER *timer_ptr);
@@ -1858,7 +1858,7 @@ VOID        _tx_time_set(ULONG new_time);
 
 UINT        _txe_timer_activate(TX_TIMER *timer_ptr);
 UINT        _txe_timer_change(TX_TIMER *timer_ptr, ULONG initial_ticks, ULONG reschedule_ticks);
-UINT        _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
+UINT        _txe_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr,
                 VOID (*expiration_function)(ULONG input), ULONG expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 UINT        _txe_timer_deactivate(TX_TIMER *timer_ptr);

--- a/common_smp/src/tx_block_pool_create.c
+++ b/common_smp/src/tx_block_pool_create.c
@@ -73,7 +73,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT  _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size)
 {
 

--- a/common_smp/src/tx_byte_pool_create.c
+++ b/common_smp/src/tx_byte_pool_create.c
@@ -72,7 +72,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _tx_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start, ULONG pool_size)
+UINT  _tx_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start, ULONG pool_size)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/src/tx_event_flags_create.c
+++ b/common_smp/src/tx_event_flags_create.c
@@ -71,7 +71,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _tx_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr)
+UINT  _tx_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/src/tx_mutex_create.c
+++ b/common_smp/src/tx_mutex_create.c
@@ -72,7 +72,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _tx_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit)
+UINT  _tx_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/src/tx_queue_create.c
+++ b/common_smp/src/tx_queue_create.c
@@ -73,7 +73,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _tx_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size,
+UINT  _tx_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size,
                         VOID *queue_start, ULONG queue_size)
 {
 

--- a/common_smp/src/txe_block_pool_create.c
+++ b/common_smp/src/txe_block_pool_create.c
@@ -81,7 +81,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT  _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size, UINT pool_control_block_size)
 {
 

--- a/common_smp/src/txe_byte_pool_create.c
+++ b/common_smp/src/txe_byte_pool_create.c
@@ -80,7 +80,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start, ULONG pool_size, UINT pool_control_block_size)
+UINT  _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start, ULONG pool_size, UINT pool_control_block_size)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/src/txe_event_flags_create.c
+++ b/common_smp/src/txe_event_flags_create.c
@@ -77,7 +77,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr, UINT event_control_block_size)
+UINT  _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr, UINT event_control_block_size)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/src/txe_mutex_create.c
+++ b/common_smp/src/txe_mutex_create.c
@@ -78,7 +78,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txe_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size)
+UINT  _txe_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/src/txe_queue_create.c
+++ b/common_smp/src/txe_queue_create.c
@@ -79,7 +79,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txe_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size,
+UINT  _txe_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size,
                         VOID *queue_start, ULONG queue_size, UINT queue_control_block_size)
 {
 

--- a/common_smp/src/txe_semaphore_create.c
+++ b/common_smp/src/txe_semaphore_create.c
@@ -77,7 +77,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size)
+UINT  _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size)
 {
 
 TX_INTERRUPT_SAVE_AREA

--- a/common_smp/src/txe_thread_create.c
+++ b/common_smp/src/txe_thread_create.c
@@ -86,7 +86,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT    _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr,
+UINT    _txe_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr,
                 VOID (*entry_function)(ULONG id), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size,
                 UINT priority, UINT preempt_threshold,

--- a/common_smp/src/txe_timer_create.c
+++ b/common_smp/src/txe_timer_create.c
@@ -81,7 +81,7 @@
 /*                                            resulting in version 6.1    */
 /*                                                                        */
 /**************************************************************************/
-UINT  _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr,
+UINT  _txe_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr,
             VOID (*expiration_function)(ULONG id), ULONG expiration_input,
             ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size)
 {

--- a/test/smp/regression/threadx_block_memory_basic_test.c
+++ b/test/smp/regression/threadx_block_memory_basic_test.c
@@ -60,7 +60,7 @@ void  test_control_return(UINT status);
 
 /* Prototype direct call to block pool core service.  */
 
-UINT  _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT  _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size);
 
 

--- a/test/smp/regression/threadx_block_memory_error_detection_test.c
+++ b/test/smp/regression/threadx_block_memory_error_detection_test.c
@@ -17,7 +17,7 @@ static CHAR            *pointer;
 
 static void    thread_0_entry(ULONG thread_input);
 
-UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size, UINT pool_control_block_size);
 
 

--- a/test/smp/regression/threadx_byte_memory_basic_test.c
+++ b/test/smp/regression/threadx_byte_memory_basic_test.c
@@ -30,7 +30,7 @@ extern UINT            test_byte_pool_create_init;
 
 extern VOID    (*test_isr_dispatch)(void);
 
-UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start,
+UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start,
                     ULONG pool_size, UINT pool_control_block_size);
 
 

--- a/test/smp/regression/threadx_event_flag_basic_test.c
+++ b/test/smp/regression/threadx_event_flag_basic_test.c
@@ -46,7 +46,7 @@ static TX_EVENT_FLAGS_GROUP group_3;
 
 static void    thread_0_entry(ULONG thread_input);
 static void    thread_1_entry(ULONG thread_input);
-UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr, UINT event_control_block_size);
+UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr, UINT event_control_block_size);
 
 
 /* Prototype for test control return.  */

--- a/test/smp/regression/threadx_mutex_basic_test.c
+++ b/test/smp/regression/threadx_mutex_basic_test.c
@@ -58,7 +58,7 @@ static void    thread_2_entry(ULONG thread_input);
 static void    thread_3_entry(ULONG thread_input);
 static void    thread_4_entry(ULONG thread_input);
 
-UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
+UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
 
 
 /* Prototype for test control return.  */

--- a/test/smp/regression/threadx_queue_basic_one_word_test.c
+++ b/test/smp/regression/threadx_queue_basic_one_word_test.c
@@ -40,7 +40,7 @@ static void    thread_0_entry(ULONG thread_input);
 static void    thread_1_entry(ULONG thread_input);
 
 
-UINT        _txe_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size, 
+UINT        _txe_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size, 
                         VOID *queue_start, ULONG queue_size, UINT queue_control_block_size);
 
 

--- a/test/smp/regression/threadx_semaphore_basic_test.c
+++ b/test/smp/regression/threadx_semaphore_basic_test.c
@@ -51,7 +51,7 @@ static TX_SEMAPHORE    semaphore_3;
 static void    thread_0_entry(ULONG thread_input);
 static void    thread_1_entry(ULONG thread_input);
 
-UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
+UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
 
 
 /* Prototype for test control return.  */

--- a/test/smp/regression/threadx_thread_basic_execution_test.c
+++ b/test/smp/regression/threadx_thread_basic_execution_test.c
@@ -56,7 +56,7 @@ static unsigned long isr_executed =  0;
 
 static void    thread_0_entry(ULONG task_input);
 
-UINT        _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr, 
+UINT        _txe_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr, 
                 VOID (*entry_function)(ULONG), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size, 
                 UINT priority, UINT preempt_threshold, 

--- a/test/smp/regression/threadx_timer_simple_test.c
+++ b/test/smp/regression/threadx_timer_simple_test.c
@@ -52,7 +52,7 @@ static void    thread_1_entry(ULONG thread_input);
 static void    timer_0_expiration(ULONG timer_input);
 static void    timer_1_expiration(ULONG timer_input);
 
-UINT        _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr, 
+UINT        _txe_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr, 
                 VOID (*expiration_function)(ULONG), ULONG expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 

--- a/test/tx/regression/threadx_block_memory_basic_test.c
+++ b/test/tx/regression/threadx_block_memory_basic_test.c
@@ -60,7 +60,7 @@ void  test_control_return(UINT status);
 
 /* Prototype direct call to block pool core service.  */
 
-UINT  _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT  _tx_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size);
 
 

--- a/test/tx/regression/threadx_block_memory_error_detection_test.c
+++ b/test/tx/regression/threadx_block_memory_error_detection_test.c
@@ -17,7 +17,7 @@ static CHAR            *pointer;
 
 static void    thread_0_entry(ULONG thread_input);
 
-UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, CHAR *name_ptr, ULONG block_size,
+UINT        _txe_block_pool_create(TX_BLOCK_POOL *pool_ptr, const CHAR *name_ptr, ULONG block_size,
                     VOID *pool_start, ULONG pool_size, UINT pool_control_block_size);
 
 

--- a/test/tx/regression/threadx_byte_memory_basic_test.c
+++ b/test/tx/regression/threadx_byte_memory_basic_test.c
@@ -30,7 +30,7 @@ extern UINT            test_byte_pool_create_init;
 
 extern VOID    (*test_isr_dispatch)(void);
 
-UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, CHAR *name_ptr, VOID *pool_start,
+UINT        _txe_byte_pool_create(TX_BYTE_POOL *pool_ptr, const CHAR *name_ptr, VOID *pool_start,
                     ULONG pool_size, UINT pool_control_block_size);
 
 

--- a/test/tx/regression/threadx_event_flag_basic_test.c
+++ b/test/tx/regression/threadx_event_flag_basic_test.c
@@ -46,7 +46,7 @@ static TX_EVENT_FLAGS_GROUP group_3;
 
 static void    thread_0_entry(ULONG thread_input);
 static void    thread_1_entry(ULONG thread_input);
-UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, CHAR *name_ptr, UINT event_control_block_size);
+UINT        _txe_event_flags_create(TX_EVENT_FLAGS_GROUP *group_ptr, const CHAR *name_ptr, UINT event_control_block_size);
 
 
 /* Prototype for test control return.  */

--- a/test/tx/regression/threadx_mutex_basic_test.c
+++ b/test/tx/regression/threadx_mutex_basic_test.c
@@ -58,7 +58,7 @@ static void    thread_2_entry(ULONG thread_input);
 static void    thread_3_entry(ULONG thread_input);
 static void    thread_4_entry(ULONG thread_input);
 
-UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
+UINT        _txe_mutex_create(TX_MUTEX *mutex_ptr, const CHAR *name_ptr, UINT inherit, UINT mutex_control_block_size);
 
 
 /* Prototype for test control return.  */

--- a/test/tx/regression/threadx_queue_basic_one_word_test.c
+++ b/test/tx/regression/threadx_queue_basic_one_word_test.c
@@ -40,7 +40,7 @@ static void    thread_0_entry(ULONG thread_input);
 static void    thread_1_entry(ULONG thread_input);
 
 
-UINT        _txe_queue_create(TX_QUEUE *queue_ptr, CHAR *name_ptr, UINT message_size, 
+UINT        _txe_queue_create(TX_QUEUE *queue_ptr, const CHAR *name_ptr, UINT message_size, 
                         VOID *queue_start, ULONG queue_size, UINT queue_control_block_size);
 
 

--- a/test/tx/regression/threadx_semaphore_basic_test.c
+++ b/test/tx/regression/threadx_semaphore_basic_test.c
@@ -51,7 +51,7 @@ static TX_SEMAPHORE    semaphore_3;
 static void    thread_0_entry(ULONG thread_input);
 static void    thread_1_entry(ULONG thread_input);
 
-UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
+UINT        _txe_semaphore_create(TX_SEMAPHORE *semaphore_ptr, const CHAR *name_ptr, ULONG initial_count, UINT semaphore_control_block_size);
 
 
 /* Prototype for test control return.  */

--- a/test/tx/regression/threadx_thread_basic_execution_test.c
+++ b/test/tx/regression/threadx_thread_basic_execution_test.c
@@ -56,7 +56,7 @@ static unsigned long isr_executed =  0;
 
 static void    thread_0_entry(ULONG task_input);
 
-UINT        _txe_thread_create(TX_THREAD *thread_ptr, CHAR *name_ptr, 
+UINT        _txe_thread_create(TX_THREAD *thread_ptr, const CHAR *name_ptr, 
                 VOID (*entry_function)(ULONG), ULONG entry_input,
                 VOID *stack_start, ULONG stack_size, 
                 UINT priority, UINT preempt_threshold, 

--- a/test/tx/regression/threadx_timer_simple_test.c
+++ b/test/tx/regression/threadx_timer_simple_test.c
@@ -52,7 +52,7 @@ static void    thread_1_entry(ULONG thread_input);
 static void    timer_0_expiration(ULONG timer_input);
 static void    timer_1_expiration(ULONG timer_input);
 
-UINT        _txe_timer_create(TX_TIMER *timer_ptr, CHAR *name_ptr, 
+UINT        _txe_timer_create(TX_TIMER *timer_ptr, const CHAR *name_ptr, 
                 VOID (*expiration_function)(ULONG), ULONG expiration_input,
                 ULONG initial_ticks, ULONG reschedule_ticks, UINT auto_activate, UINT timer_control_block_size);
 

--- a/utility/rtos_compatibility_layers/posix/px_int.h
+++ b/utility/rtos_compatibility_layers/posix/px_int.h
@@ -166,7 +166,7 @@ VOID                  posix_putback_queue(TX_QUEUE * qid);
 
 sem_t                *posix_find_sem(const CHAR * name);
 
-VOID                  posix_set_sem_name(sem_t * sem, CHAR *name);
+VOID                  posix_set_sem_name(sem_t * sem, const CHAR *name);
 
 TX_SEMAPHORE         *posix_get_new_sem(VOID);
 


### PR DESCRIPTION
This pull requests fixes the compiler warning when creating TX objects with literal strings since we are passing literal string to the function accepting `CHAR *`, that can, by design, modify input parameter and therefore cause undefined system behavior.

All name pointers become `const CHAR*` type.

There is no backward incompatibility when creating objects, but there is a potential backward in-compatibility when calling `tx_<modulename>_name_get` function, because parameter shall be changed to `const char* variable`.

Currently we can get the name as:
```c
CHAR* name;
tx_thread_name_get(..., &name);
```

New required function call:
```c
const CHAR* name;
tx_thread_name_get(..., &name);
```

I've not seen tests for getting the name in the threadx, I also clearly assume that people using `_get` api are the minority.
From safety and quality standpoint, this upgrade makes a lot of sense.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [x] Added test case for bug fix or new feature
- [x] Validated on real hardware C-M4, GCC