### PR TITLE
Issue 426: Add resume and suspend hook extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ target_sources(freertos-threadx
 )
 target_link_libraries(freertos-threadx PUBLIC threadx)
 
+
+set(TX_USER_FILE "${CMAKE_CURRENT_LIST_DIR}/custom_tx_user.h" CACHE PATH "Path to custom tx_user.h")
+
 # If the user provided an override, copy it to the custom directory
 if (NOT TX_USER_FILE)
     message(STATUS "Using default tx_user.h file")
@@ -55,7 +58,7 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC 
     ${CUSTOM_INC_DIR}
 )
-target_compile_definitions(${PROJECT_NAME} PUBLIC "TX_INCLUDE_USER_DEFINE_FILE" )
+target_compile_definitions(${PROJECT_NAME} PUBLIC "TX_INCLUDE_USER_DEFINE_FILE" "TX_ENABLE_THREAD_SYSTEM_RESUME_EXTENSION")
 
 # Enable a build target that produces a ZIP file of all sources
 set(CPACK_SOURCE_GENERATOR "ZIP")

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(${PROJECT_NAME}
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_stack_error_handler.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_stack_error_notify.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_suspend.c
+	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_suspend_resume_extension.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_system_preempt_check.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_system_resume.c
 	${CMAKE_CURRENT_LIST_DIR}/src/tx_thread_system_suspend.c

--- a/common/inc/tx_api.h
+++ b/common/inc/tx_api.h
@@ -25,7 +25,7 @@
 /*  APPLICATION INTERFACE DEFINITION                       RELEASE        */
 /*                                                                        */
 /*    tx_api.h                                            PORTABLE C      */
-/*                                                           6.4.1        */
+/*                                                           6.4.2        */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    William E. Lamie, Microsoft Corporation                             */
@@ -106,7 +106,10 @@
 /*  03-01-2024      Tiejun Zhou             Modified comment(s),          */
 /*                                            update version number,      */
 /*                                            resulting in version 6.4.1  */
-/*                                                                        */
+/*  XX-XX-2025      Greg Link               Modified comment(s),          */
+/*                                            update version number,      */
+/*                                            add resume/suspend hooks,   */
+/*                                            resulting in version 6.4.2  */
 /**************************************************************************/
 
 #ifndef TX_API_H
@@ -1779,6 +1782,22 @@ UINT        _tx_thread_terminate(TX_THREAD *thread_ptr);
 UINT        _tx_thread_time_slice_change(TX_THREAD *thread_ptr, ULONG new_time_slice, ULONG *old_time_slice);
 UINT        _tx_thread_wait_abort(TX_THREAD *thread_ptr);
 
+/* Two alternative ways to include the proposed extensions of Issue 426.
+   The first expects the extension to always have the same function prototype, 
+   but it is a proper function, while the second uses a #define in tx_user.h
+   to extend the functionality instead. */
+
+#ifdef TX_ENABLE_THREAD_SYSTEM_RESUME_EXTENSION
+UINT _tx_thread_system_resume_extension(TX_THREAD *thread_ptr);
+#define TX_THREAD_SYSTEM_RESUME_EXTENSION(a) _tx_thread_system_resume_extension(a)
+#else
+#warning TX_ENABLE_THREAD_SYSTEM_RESUME_EXTENSION is disabled
+#define TX_THREAD_SYSTEM_RESUME_EXTENSION(a) ((void)(a))
+#endif
+
+#ifndef TX_THREAD_SYSTEM_SUSPEND_EXTENSION
+#define TX_THREAD_SYSTEM_SUSPEND_EXTENSION(a) ((void)(a))
+#endif
 
 /* Define error checking shells for API services.  These are only referenced by the
    application.  */

--- a/common/src/tx_thread_resume.c
+++ b/common/src/tx_thread_resume.c
@@ -241,6 +241,9 @@ UINT            map_index;
         /* Log the thread status change.  */
         TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, TX_READY)
 
+        /* Handle the thread resume extension, if defined*/
+        TX_THREAD_SYSTEM_RESUME_EXTENSION(thread_ptr);
+
 #ifdef TX_THREAD_ENABLE_PERFORMANCE_INFO
 
         /* Increment the total number of thread resumptions.  */

--- a/common/src/tx_thread_suspend.c
+++ b/common/src/tx_thread_suspend.c
@@ -309,6 +309,10 @@ ULONG                       time_stamp =  ((ULONG) 0);
             /* Log the thread status change.  */
             TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, thread_ptr -> tx_thread_state)
 
+
+            /* Handle the thread suspend extension, if defined*/
+            TX_THREAD_SYSTEM_SUSPEND_EXTENSION(thread_ptr);
+
 #ifdef TX_ENABLE_EVENT_TRACE
 
             /* If trace is enabled, save the current event pointer.  */

--- a/common/src/tx_thread_suspend_resume_extension.c
+++ b/common/src/tx_thread_suspend_resume_extension.c
@@ -1,0 +1,34 @@
+/***************************************************************************
+ * Copyright (c) 2025 Microsoft Corporation 
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License which is available at
+ * https://opensource.org/licenses/MIT.
+ * 
+ * SPDX-License-Identifier: MIT
+ **************************************************************************/
+
+/* Include necessary system files.  */
+
+#include "tx_api.h"
+#include "tx_trace.h"
+#include "tx_thread.h"
+#include "tx_initialize.h"
+
+/* Test only, demo of user extension. If the below is not defined,
+    no need to include this function at all - it will never be called */
+#ifdef TX_ENABLE_THREAD_SYSTEM_RESUME_EXTENSION
+
+UINT  _tx_thread_system_resume_extension(TX_THREAD *thread_ptr)
+{
+    UINT status = 0;
+    if (!thread_ptr->resume_recorded)
+    {
+        thread_ptr->resume_recorded_at += 1;
+    }
+
+    /* Return completion status. */
+    return(status);
+}
+
+#endif //TX_ENABLE_THREAD_SYSTEM_RESUME_EXTENSION

--- a/common/src/tx_thread_system_resume.c
+++ b/common/src/tx_thread_system_resume.c
@@ -182,6 +182,9 @@ UINT            map_index;
                 /* Log the thread status change.  */
                 TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, TX_READY)
 
+                /* Handle the thread resume extension, if defined*/
+                TX_THREAD_SYSTEM_RESUME_EXTENSION(thread_ptr);
+
 #ifdef TX_THREAD_ENABLE_PERFORMANCE_INFO
 
                 /* Increment the total number of thread resumptions.  */
@@ -435,6 +438,9 @@ UINT            map_index;
 
                     /* Log the thread status change.  */
                     TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, TX_READY)
+
+                    /* Handle the thread resume extension, if defined*/
+                    TX_THREAD_SYSTEM_RESUME_EXTENSION(thread_ptr);
                 }
                 else
                 {
@@ -600,6 +606,9 @@ UINT            state;
                 /* Log the thread status change.  */
                 TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, TX_READY)
 
+                /* Handle the thread resume extension, if defined*/
+                TX_THREAD_SYSTEM_RESUME_EXTENSION(thread_ptr);
+
 #ifdef TX_THREAD_ENABLE_PERFORMANCE_INFO
 
                 /* Increment the total number of thread resumptions.  */
@@ -701,6 +710,9 @@ UINT            map_index;
 
             /* Log the thread status change.  */
             TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, TX_READY)
+
+            /* Handle the thread resume extension, if defined*/
+            TX_THREAD_SYSTEM_RESUME_EXTENSION(thread_ptr);
 
             /* Pickup priority of thread.  */
             priority =  thread_ptr -> tx_thread_priority;

--- a/common/src/tx_thread_system_suspend.c
+++ b/common/src/tx_thread_system_suspend.c
@@ -169,6 +169,9 @@ ULONG                       time_stamp =  ((ULONG) 0);
         /* Log the thread status change.  */
         TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, thread_ptr -> tx_thread_state)
 
+        /* Handle the thread suspend extension, if defined*/
+        TX_THREAD_SYSTEM_SUSPEND_EXTENSION(thread_ptr);
+
 #ifdef TX_ENABLE_EVENT_TRACE
 
         /* If trace is enabled, save the current event pointer.  */
@@ -760,6 +763,9 @@ ULONG                       time_stamp =  ((ULONG) 0);
 
     /* Log the thread status change.  */
     TX_EL_THREAD_STATUS_CHANGE_INSERT(thread_ptr, thread_ptr -> tx_thread_state)
+
+    /* Handle the thread suspend extension, if defined*/
+    TX_THREAD_SYSTEM_SUSPEND_EXTENSION(thread_ptr);
 
 #ifdef TX_ENABLE_EVENT_TRACE
 

--- a/custom_tx_user.h
+++ b/custom_tx_user.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+ * Copyright (c) 2024 Microsoft Corporation 
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License which is available at
+ * https://opensource.org/licenses/MIT.
+ * 
+ * SPDX-License-Identifier: MIT
+ **************************************************************************/
+
+#ifndef TX_USER_H
+#define TX_USER_H
+
+/*  Define user-specified additional fields to be stored in TX_THREAD */
+#define TX_THREAD_USER_EXTENSION       UCHAR resume_recorded; \
+                                       ULONG resume_recorded_at; \
+                                       UCHAR suspend_recorded; \
+                                       ULONG suspend_recorded_at; 
+
+/* This is one way to define the extension. Because it's a macro, it
+   cannot handle static allocations internally, nor does it have a 
+   proper calling context for tracing purposes. */
+#define TX_THREAD_SYSTEM_SUSPEND_EXTENSION(thread_ptr) \
+do { \
+    if (!thread_ptr->suspend_recorded) \
+    { \
+        thread_ptr->suspend_recorded_at += 1; \
+        thread_ptr->suspend_recorded = 1; \
+    } \
+} while(0)
+
+#endif
+


### PR DESCRIPTION
Existing ThreadX source has a very powerful hook for thread entry and exit. This hook allows tracking of processor utilization for each task (by observing when it enters and leaves the processor), as well as any other usage deemed appropriate by the developer.

No such equivalent hook(s) exist for the suspension and resumption of threads, making it difficult to observe how long from the time a thread becomes ready until it first enters the processor, and eventually is suspended as well.

This pull request adds such hooks. At the same time, it does not follow the format and structure of the entry and exit hooks, as those were written with the expectation that developers and users would not have direct access to the source code, and as such, the hooks are less performant than they could otherwise be. This pull request therefore uses a more direct approach to allow installation of callback extensions that should have no performance impact when not enabled.

### Work In Progress ###
This is not a mergeable commit, as it includes modifications to things that should not be committed upstream. Importantly, it shows two possible approaches to installing/including the hooks. Furthermore, I have not yet benchmarked any performance impact of a system with the hooks enabled vs a system without the hooks.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [ ] Validated on real hardware <!-- hardware - toolchain -->