### PR TITLE
basic processing case shows no results with O2

### DIFF
--- a/utility/benchmarks/thread_metric/tm_basic_processing_test.c
+++ b/utility/benchmarks/thread_metric/tm_basic_processing_test.c
@@ -46,7 +46,7 @@
 
 /* Define the counters used in the demo application...  */
 
-unsigned long   tm_basic_processing_counter;
+volatile unsigned long   tm_basic_processing_counter;
 
 
 /* Test array.  We will just do a series of calculations on the 


### PR DESCRIPTION
## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [x] Validated on real hardware <!-- hardware - toolchain -->

When compiling with the arm-none-eabi-gcc 13.2.1 with "-O2" for v8-r, this test case just outputs "0" as the result.