### PR TITLE
Fix undefined IRQ_MASK/FIQ_MASK in Cortex-A GNU/AC6 ports with VFP enabled

### DIFF
--- a/ports/cortex_a12/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a12/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a12/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a12/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a15/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a15/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a15/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a15/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a17/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a17/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a17/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a17/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a5/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a5/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a5/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a5/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a7/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a7/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a7/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a7/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a8/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a8/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a8/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a8/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a9/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a9/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a9/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a9/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports_arch/ARMv7-A/threadx/common/src/tx_thread_schedule.S
+++ b/ports_arch/ARMv7-A/threadx/common/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */


### PR DESCRIPTION
## Description
This PR fixes a compilation error in `tx_thread_schedule.S` for ARM Cortex-A ports (GNU and AC6) when `TX_ENABLE_VFP_SUPPORT` is defined.

When VFP support is enabled, the context restore logic at the end of the scheduling loop attempts to use `IRQ_MASK` and `FIQ_MASK` to manage interrupt state. However, these symbols are not defined in the assembly files, leading to build failures:
`undefined symbol IRQ_MASK used as an immediate value`

This issue appears to be present across multiple Cortex-A ports (GNU and AC6). This PR adds the missing definitions (IRQ_MASK = 0x80, FIQ_MASK = 0x40) to the affected files.

## Fix
Added local definitions for `IRQ_MASK` and `FIQ_MASK` in `tx_thread_schedule.S`. This aligns with the definitions found in `tx_thread_interrupt_restore.S` and enables successful compilation of the VFP context switch logic.

## Validation
**Hardware:** Xilinx Zynq-7000 (ZC702)
**Toolchain:** GNU Arm Embedded Toolchain
**Verification:**
1. Configured BSP with `-DTX_ENABLE_VFP_SUPPORT`.
2. Encountered build failure due to missing symbols.
3. Applied the fix.
4. Validated successful compilation and basic context switching on hardware.

## PR checklist
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [x] Validated on real hardware