### PR TITLE
Fix VFP build failure in Cortex-A tx_thread_schedule.S

### DIFF
--- a/ports/cortex_a12/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a12/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a12/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a12/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a12/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a12/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a12/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a12/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a15/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a15/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a15/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a15/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a15/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a15/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a15/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a15/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a15/iar/src/tx_thread_schedule.s
+++ b/ports/cortex_a15/iar/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -238,4 +239,5 @@ __tx_no_thread_to_disable
 #endif
 
     END
+
 

--- a/ports/cortex_a17/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a17/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a17/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a17/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a17/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a17/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a17/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a17/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a34/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a34/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -225,3 +226,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a34/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a34/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -231,3 +232,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a35/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a35/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a35/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a35/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a5/ac5/src/tx_thread_schedule.s
+++ b/ports/cortex_a5/ac5/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -232,4 +233,5 @@ __tx_no_thread_to_disable
     ENDIF
 
     END
+
 

--- a/ports/cortex_a5/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a5/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a5/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a5/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a5/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a5/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a5/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a5/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a5/iar/src/tx_thread_schedule.s
+++ b/ports/cortex_a5/iar/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -242,4 +243,5 @@ __tx_no_thread_to_disable:
 #endif
 
     END
+
 

--- a/ports/cortex_a53/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a53/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a53/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a53/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a55/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a55/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a55/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a55/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a57/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a57/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a57/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a57/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a5x/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a5x/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -235,5 +236,6 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller    
 /* } */
+
 
 

--- a/ports/cortex_a65/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a65/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a65/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a65/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a65ae/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a65ae/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a65ae/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a65ae/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a7/ac5/src/tx_thread_schedule.s
+++ b/ports/cortex_a7/ac5/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -232,4 +233,5 @@ __tx_no_thread_to_disable
     ENDIF
 
     END
+
 

--- a/ports/cortex_a7/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a7/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a7/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a7/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a7/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a7/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a7/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a7/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a7/iar/src/tx_thread_schedule.s
+++ b/ports/cortex_a7/iar/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -238,4 +239,5 @@ __tx_no_thread_to_disable:
 #endif
 
     END
+
 

--- a/ports/cortex_a72/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a72/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a72/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a72/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a73/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a73/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a73/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a73/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a75/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a75/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a75/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a75/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a76/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a76/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a76/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a76/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a76ae/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a76ae/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a76ae/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a76ae/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a77/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a77/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a77/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a77/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -230,3 +231,4 @@ _skip_solicited_fp_restore:
     MSR     DAIF, x4                            // Recover DAIF
     RET                                         // Return to caller
 // }
+

--- a/ports/cortex_a8/ac5/src/tx_thread_schedule.s
+++ b/ports/cortex_a8/ac5/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -232,4 +233,5 @@ __tx_no_thread_to_disable
     ENDIF
 
     END
+
 

--- a/ports/cortex_a8/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a8/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a8/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a8/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a8/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a8/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a8/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a8/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a8/iar/src/tx_thread_schedule.s
+++ b/ports/cortex_a8/iar/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -238,4 +239,5 @@ __tx_no_thread_to_disable:
 #endif
 
     END
+
 

--- a/ports/cortex_a9/ac5/src/tx_thread_schedule.s
+++ b/ports/cortex_a9/ac5/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -232,4 +233,5 @@ __tx_no_thread_to_disable
     ENDIF
 
     END
+
 

--- a/ports/cortex_a9/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a9/ac6/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a9/ac6/src/tx_thread_schedule.S
+++ b/ports/cortex_a9/ac6/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a9/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a9/gnu/src/tx_thread_schedule.S
@@ -39,6 +39,14 @@
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
 
+#ifdef TX_ENABLE_VFP_SUPPORT
+IRQ_MASK        =   0x080
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+FIQ_MASK        =   0x040
+#endif
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/ports/cortex_a9/gnu/src/tx_thread_schedule.S
+++ b/ports/cortex_a9/gnu/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -40,11 +41,11 @@
 #define SVC_MODE    0x13            // SVC mode
 
 #ifdef TX_ENABLE_VFP_SUPPORT
-IRQ_MASK        =   0x080
+#define IRQ_MASK    0x80
 #endif
 
 #ifdef TX_ENABLE_FIQ_SUPPORT
-FIQ_MASK        =   0x040
+#define FIQ_MASK    0x40
 #endif
 
 /**************************************************************************/
@@ -267,3 +268,4 @@ no_fiq:
     BX      lr
 
 #endif
+

--- a/ports/cortex_a9/iar/src/tx_thread_schedule.s
+++ b/ports/cortex_a9/iar/src/tx_thread_schedule.s
@@ -1,5 +1,6 @@
 ;/***************************************************************************
 ; * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors 
 ; * 
 ; * This program and the accompanying materials are made available under the
 ; * terms of the MIT License which is available at
@@ -239,4 +240,5 @@ __tx_no_thread_to_disable:
 #endif
 
     END
+
 

--- a/ports_arch/ARMv7-A/threadx/common/src/tx_thread_schedule.S
+++ b/ports_arch/ARMv7-A/threadx/common/src/tx_thread_schedule.S
@@ -1,5 +1,6 @@
 /***************************************************************************
  * Copyright (c) 2024 Microsoft Corporation 
+ * Copyright (C) 2026-present Eclipse ThreadX contributors
  * 
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
@@ -38,6 +39,14 @@
 
 #define IRQ_MODE    0x12            // IRQ mode
 #define SVC_MODE    0x13            // SVC mode
+
+#ifdef TX_ENABLE_VFP_SUPPORT
+#define IRQ_MASK    0x80
+#endif
+
+#ifdef TX_ENABLE_FIQ_SUPPORT
+#define FIQ_MASK    0x40
+#endif
 
 /**************************************************************************/
 /*                                                                        */


### PR DESCRIPTION
## Description

Fixes undefined symbol errors (`IRQ_MASK` / `FIQ_MASK`) when building Cortex-A ports (GNU/AC6) with `TX_ENABLE_VFP_SUPPORT`.

These masks (0x80/0x40) are required for the VFP context restore logic but were missing from `tx_thread_schedule.S`.

## Validation

**Hardware:** Xilinx Zynq-7000 (ZC702)
**Toolchain:** GNU Arm Embedded
**Result:** Confirmed successful compilation and context switching with `-DTX_ENABLE_VFP_SUPPORT`.

## PR checklist

* [ ] Updated function header with a short description and version number
* [ ] Added test case for bug fix or new feature
* [x] Validated on real hardware