### PR TITLE
Added missing ULONG64 definition for RX ports needed by USBX and NetX Duo

### DIFF
--- a/ports/rxv1/ccrx/inc/tx_port.h
+++ b/ports/rxv1/ccrx/inc/tx_port.h
@@ -82,8 +82,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv1/gnu/inc/tx_port.h
+++ b/ports/rxv1/gnu/inc/tx_port.h
@@ -84,8 +84,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv1/iar/inc/tx_port.h
+++ b/ports/rxv1/iar/inc/tx_port.h
@@ -85,8 +85,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv2/ccrx/inc/tx_port.h
+++ b/ports/rxv2/ccrx/inc/tx_port.h
@@ -84,8 +84,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv2/gnu/inc/tx_port.h
+++ b/ports/rxv2/gnu/inc/tx_port.h
@@ -86,8 +86,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv2/iar/inc/tx_port.h
+++ b/ports/rxv2/iar/inc/tx_port.h
@@ -87,8 +87,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv3/ccrx/inc/tx_port.h
+++ b/ports/rxv3/ccrx/inc/tx_port.h
@@ -83,8 +83,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv3/gnu/inc/tx_port.h
+++ b/ports/rxv3/gnu/inc/tx_port.h
@@ -85,8 +85,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */

--- a/ports/rxv3/iar/inc/tx_port.h
+++ b/ports/rxv3/iar/inc/tx_port.h
@@ -86,8 +86,10 @@ typedef int                                     INT;
 typedef unsigned int                            UINT;
 typedef long                                    LONG;
 typedef unsigned long                           ULONG;
+typedef unsigned long long                      ULONG64;
 typedef short                                   SHORT;
 typedef unsigned short                          USHORT;
+#define ULONG64_DEFINED
 
 
 /* Define interrupt control options.  */


### PR DESCRIPTION
## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [x] Validated on real hardware: rxv2/gnu