### PR TITLE
Add RISC-V64 CI workflow for BPI-F3 support

### DIFF
--- a/.github/workflows/ci_riscv64.yml
+++ b/.github/workflows/ci_riscv64.yml
@@ -1,0 +1,40 @@
+name: riscv64
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    paths:
+      - ".github/workflows/ci_riscv64.yml"
+      - 'common/**'
+      - 'utility/**'
+      - 'ports/risc-v64/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: RISC-V64 build
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Install RISC-V toolchain
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-riscv64-unknown-elf
+
+    - name: Install cmake 3.19.1
+      uses: lukka/get-cmake@v3.19.1
+
+    - name: Install ninja-build
+      uses: seanmiddleditch/gha-setup-ninja@v3
+
+    - name: Prepare build system
+      run: cmake -Bbuild -DCMAKE_TOOLCHAIN_FILE=./cmake/riscv64_gnu.cmake -GNinja .
+
+    - name: Compile and link
+      run: cmake --build ./build

--- a/.github/workflows/ci_riscv64.yml
+++ b/.github/workflows/ci_riscv64.yml
@@ -30,8 +30,6 @@ jobs:
     - name: Install cmake 3.19.1
       uses: lukka/get-cmake@v3.19.1
 
-    - name: Install ninja-build
-      uses: seanmiddleditch/gha-setup-ninja@v3
 
     - name: Prepare build system
       run: cmake -Bbuild -DCMAKE_TOOLCHAIN_FILE=./cmake/riscv64_gnu.cmake -GNinja .


### PR DESCRIPTION
Summary

This PR adds a GitHub Actions workflow for RISC-V64 builds using the existing riscv64_gnu.cmake toolchain configuration.

Motivation

Closes #487

Issue #487 proposes adding Banana Pi BPI-F3 board support into the CI pipeline. Since ThreadX already provides a RISC-V64 GNU port and CMake toolchain configuration, this workflow ensures that the riscv64 port builds successfully in CI.

Changes

Added .github/workflows/ci_riscv64.yml

Installs gcc-riscv64-unknown-elf

Builds using Ninja and existing toolchain file