### PR TITLE
update qemu examples as per new rv port format

### DIFF
--- a/ports/risc-v32/gnu/example_build/qemu_virt/tx_initialize_low_level.S
+++ b/ports/risc-v32/gnu/example_build/qemu_virt/tx_initialize_low_level.S
@@ -9,7 +9,6 @@
  **************************************************************************/
 
 #include "csr.h"
-#include "tx_port.h"
 
  .section .text
  .align 4
@@ -67,12 +66,12 @@
     .extern  _tx_thread_context_restore
     trap_entry:
 #if defined(__riscv_float_abi_single) || defined(__riscv_float_abi_double)
-	addi sp, sp, -65*REGBYTES         // Allocate space for all registers - with floating point enabled
+	addi sp, sp, -260         // Allocate space for all registers - with floating point enabled
 #else
-	addi sp, sp, -32*REGBYTES         // Allocate space for all registers - without floating point enabled
+	addi sp, sp, -128         // Allocate space for all registers - without floating point enabled
 #endif
 
-	STORE   x1, 28*REGBYTES(sp)       // Store RA, 28*REGBYTES(because call will override ra [ra is a calle register in riscv])
+	sw   x1, 112(sp)         // Store RA (28*4 = 112, because call will override ra [ra is a callee register in riscv])
 
     	call    _tx_thread_context_save
 
@@ -139,11 +138,6 @@ _err:
     .extern  board_init
 _tx_initialize_low_level:
 
-/*  debug print
-    .section .rodata
-debug_str_init:
-    .string "DEBUG : threadx/ports/risc-v32/gnu/example_build/qemu_virt/tx_initialize_low_level.S, _tx_initialize_low_level\n"
-*/
     .section .text
 
     la      t0, _tx_thread_system_stack_ptr
@@ -166,10 +160,6 @@ debug_str_init:
     addi    sp, sp, -4
     sw	    ra, 0(sp)
     call    board_init
-/*  debug print
-    la      a0, debug_str_init
-    call    uart_puts
-*/
     lw	    ra, 0(sp)
     addi    sp, sp, 4
     la	    t0, trap_entry

--- a/ports/risc-v32/gnu/example_build/qemu_virt/tx_initialize_low_level.S
+++ b/ports/risc-v32/gnu/example_build/qemu_virt/tx_initialize_low_level.S
@@ -66,9 +66,9 @@
     .extern  _tx_thread_context_restore
     trap_entry:
 #if defined(__riscv_float_abi_single) || defined(__riscv_float_abi_double)
-	addi sp, sp, -260         // Allocate space for all registers - with floating point enabled
+	addi sp, sp, -260         // Allocate space for all registers - with floating point enabled (65*4)
 #else
-	addi sp, sp, -128         // Allocate space for all registers - without floating point enabled
+	addi sp, sp, -128         // Allocate space for all registers - without floating point enabled (32*4)
 #endif
 
 	sw   x1, 112(sp)         // Store RA (28*4 = 112, because call will override ra [ra is a callee register in riscv])

--- a/ports/risc-v64/gnu/example_build/qemu_virt/demo_threadx.c
+++ b/ports/risc-v64/gnu/example_build/qemu_virt/demo_threadx.c
@@ -5,7 +5,7 @@
 #include "tx_api.h"
 #include "uart.h"
 #define DEMO_STACK_SIZE         1024
-#define DEMO_BYTE_POOL_SIZE     9120
+#define DEMO_BYTE_POOL_SIZE     9180
 #define DEMO_BLOCK_POOL_SIZE    100
 #define DEMO_QUEUE_SIZE         100
 

--- a/ports/risc-v64/gnu/example_build/qemu_virt/tx_initialize_low_level.S
+++ b/ports/risc-v64/gnu/example_build/qemu_virt/tx_initialize_low_level.S
@@ -9,7 +9,6 @@
  **************************************************************************/
 
 #include "csr.h"
-#include "tx_port.h"
 
  .section .text
  .align 4
@@ -67,12 +66,12 @@
     .extern  _tx_thread_context_restore
     trap_entry:
 #if defined(__riscv_float_abi_single) || defined(__riscv_float_abi_double)
-	addi sp, sp, -65*REGBYTES         // Allocate space for all registers - with floating point enabled
+	addi sp, sp, -520                 // Allocate space for all registers - with floating point enabled (65*8)
 #else
-	addi sp, sp, -32*REGBYTES         // Allocate space for all registers - without floating point enabled
+	addi sp, sp, -256                 // Allocate space for all registers - without floating point enabled (32*8)
 #endif
 
-	STORE   x1, 28*REGBYTES(sp)       // Store RA, 28*REGBYTES(because call will override ra [ra is a calle register in riscv])
+	sd   x1, 224(sp)                  // Store RA (28*8 = 224, because call will override ra [ra is a callee register in riscv])
 
     	call    _tx_thread_context_save    	
 
@@ -138,19 +137,21 @@ _err:
     .extern  _end
     .extern  board_init
 _tx_initialize_low_level:
-    sd      sp, _tx_thread_system_stack_ptr, t0     // Save system stack pointer
+    la      t0, _tx_thread_system_stack_ptr
+    sd      sp, 0(t0)                              // Save system stack pointer
 
-    la      t0, _end            		    // Pickup first free address
-    sd      t0, _tx_initialize_unused_memory, t1    // Save unused memory address
+    la      t0, _end            		           // Pickup first free address
+    la      t1, _tx_initialize_unused_memory
+    sd      t0, 0(t1)                              // Save unused memory address
     li      t0, MSTATUS_MIE
-    csrrc   zero, mstatus, t0			    // clear MSTATUS_MIE bit
+    csrrc   zero, mstatus, t0			           // clear MSTATUS_MIE bit
     li 	    t0, (MSTATUS_MPP_M | MSTATUS_MPIE )
-    csrrs   zero, mstatus, t0			    // set MSTATUS_MPP, MPIE bit
+    csrrs   zero, mstatus, t0			           // set MSTATUS_MPP, MPIE bit
     li	    t0, (MIE_MTIE | MIE_MSIE | MIE_MEIE)
-    csrrs   zero, mie, t0			    // set mie
+    csrrs   zero, mie, t0			               // set mie
 #ifdef __riscv_flen
     li      t0, MSTATUS_FS
-    csrrs   zero, mstatus, t0			    // set MSTATUS_FS bit to open f/d isa in riscv
+    csrrs   zero, mstatus, t0			           // set MSTATUS_FS bit to open f/d isa in riscv
     fscsr   x0
 #endif
     addi    sp, sp, -8


### PR DESCRIPTION
- removed the REGBYTES, STORE/LOAD macros from riscv qemu examples
- removed the tx_port.h dependency in .S

as per discussion in #496, #490 we do not want to add macros, tx_port.h dependency in .S files anymore. We have already updated the riscv 32/64 ports, updating the qemu examples accordingly. 

cc @fdesbiens 