### PR TITLE
Fixed TX_TIMER_TICKS_PER_SECOND default value in tx_user_sample.h

### DIFF
--- a/common/inc/tx_user_sample.h
+++ b/common/inc/tx_user_sample.h
@@ -95,7 +95,7 @@
    the new value must be a multiple of ULONG. */
 
 /*
-#define TX_QUEUE_MESSAGE_MAX_SIZE              TX_ULONG_16
+#define TX_QUEUE_MESSAGE_MAX_SIZE              TX_16_ULONG
 */
 
 /* Define the common timer tick reference for use by other middleware components. The default


### PR DESCRIPTION
Changed default value to TX_16_ULONG.