### PR TITLE
cmake: fixed THREADX_ARCH undefined when building as standalone library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
+# Declare the project with C only first so that CMake loads the toolchain file,
+# which sets THREADX_ARCH and THREADX_TOOLCHAIN as normal variables.  Checking
+# those variables before project() would always fail because the toolchain is
+# not sourced until the first project() call.
+project(threadx LANGUAGES C)
+
 if(NOT DEFINED THREADX_ARCH)
     message(FATAL_ERROR "Error: THREADX_ARCH not defined")
 endif()
@@ -7,22 +13,13 @@ if(NOT DEFINED THREADX_TOOLCHAIN)
     message(FATAL_ERROR "Error: THREADX_TOOLCHAIN not defined")
 endif()
 
-# The Windows simulation ports build cleanly without executable try-compiles.
-if((THREADX_ARCH STREQUAL "win32") OR (THREADX_ARCH STREQUAL "win64"))
-    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-endif()
-
-# Set up the project. The Windows simulation ports do not use assembly and
-# avoiding ASM language enablement keeps MSVC configuration on the CLI path
-# deterministic.
-if((THREADX_ARCH STREQUAL "win32") OR (THREADX_ARCH STREQUAL "win64"))
-    project(threadx
-        LANGUAGES C
-    )
-else()
-    project(threadx
-        LANGUAGES C ASM
-    )
+# The Windows simulation ports do not use assembly.  All other ports require
+# it.  enable_language() is called here rather than in project() above so that
+# the ASM toolchain is only activated when we know the target actually needs it.
+# Note: CMAKE_TRY_COMPILE_TARGET_TYPE is already set to STATIC_LIBRARY by
+# every toolchain file in cmake/, so it does not need to be repeated here.
+if(NOT ((THREADX_ARCH STREQUAL "win32") OR (THREADX_ARCH STREQUAL "win64")))
+    enable_language(ASM)
 endif()
 
 option(THREADX_SMP "Build ThreadX SMP version" OFF)


### PR DESCRIPTION
CMake loads the toolchain file during the first project() call. Variables set in the toolchain (THREADX_ARCH, THREADX_TOOLCHAIN) were therefore not visible before project() was invoked.  Commit 2c16114a moved project() after those checks to conditionally select LANGUAGES and CMAKE_TRY_COMPILE_TARGET_TYPE for Windows, which broke standalone builds that rely on the toolchain to supply THREADX_ARCH.

Fixed by calling project(threadx LANGUAGES C) first so the toolchain is sourced, then checking THREADX_ARCH, then conditionally enabling ASM via enable_language(ASM) for non-Windows ports.  The CMAKE_TRY_COMPILE_TARGET_TYPE override was removed from CMakeLists.txt because every toolchain file in cmake/ already sets it to STATIC_LIBRARY where needed.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] Updated function header with a short description and version number
- [x] Added test case for bug fix or new feature
- [x] Validated on real hardware <!-- hardware - toolchain -->