### PR TITLE
Fix nested comment warning in RX GCC ports

### DIFF
--- a/ports/rxv1/gnu/src/tx_thread_context_save.S
+++ b/ports/rxv1/gnu/src/tx_thread_context_save.S
@@ -69,7 +69,7 @@ __tx_thread_context_save:
 ;                           SP+4 ->     Saved R1
 ;                           SP+8 ->     Saved R2
 ;                           SP+12->     Interrupted PC
-;                           SP+16->     Interrupted PSW
+;                           SP+16->     Interrupted PSW  */
 ;
 ;    /* Check for a nested interrupt condition.  */
 ;    if (_tx_thread_system_state++)

--- a/ports/rxv2/gnu/src/tx_thread_context_save.S
+++ b/ports/rxv2/gnu/src/tx_thread_context_save.S
@@ -79,7 +79,7 @@ __tx_thread_context_save:
 ;                           SP+4 ->     Saved R1
 ;                           SP+8 ->     Saved R2
 ;                           SP+12->     Interrupted PC
-;                           SP+16->     Interrupted PSW
+;                           SP+16->     Interrupted PSW  */
 ;
 ;    /* Check for a nested interrupt condition.  */
 ;    if (_tx_thread_system_state++)

--- a/ports/rxv3/gnu/src/tx_thread_context_save.S
+++ b/ports/rxv3/gnu/src/tx_thread_context_save.S
@@ -79,7 +79,7 @@ __tx_thread_context_save:
 ;                           SP+4 ->     Saved R1
 ;                           SP+8 ->     Saved R2
 ;                           SP+12->     Interrupted PC
-;                           SP+16->     Interrupted PSW
+;                           SP+16->     Interrupted PSW  */
 ;
 ;    /* Check for a nested interrupt condition.  */
 ;    if (_tx_thread_system_state++)


### PR DESCRIPTION
The RX GCC assembly port contains an unclosed C-style comment in `tx_thread_context_save.S`. As discussed in #397, `.S` files are passed through the C preprocessor before assembly, so the later C-style comment can trigger GCC warnings. The warning is small, but it adds avoidable noise to RX GCC builds.

This PR closes the affected comment block without changing assembly instructions or runtime behavior.

## Validation

- Ran `git diff --check`.
- Verified RX GCC version: `8.3.0.202405-GNURX`.
- Ran RX GCC preprocessing and assembly compilation for the affected RXv1, RXv2, and RXv3 `tx_thread_context_save.S` files with `-Wcomment -Werror=comment`.
- Built standalone ThreadX static libraries out-of-tree for RXv1, RXv2, and RXv3 using RX GCC 8.3.0.202405-GNURX with `-misa=v1`, `-misa=v2`, and `-misa=v3`.

The RX GCC preprocessing, assembly compilation, and standalone static-library builds completed successfully.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [ ] Validated on real hardware <!-- hardware - toolchain -->