### PR TITLE
Marked txm_module_object_deallocate as deprecated

### DIFF
--- a/common_modules/module_lib/src/txm_module_object_deallocate.c
+++ b/common_modules/module_lib/src/txm_module_object_deallocate.c
@@ -23,6 +23,27 @@
 #define TXM_MODULE
 #include "txm_module.h"
 #ifndef TXM_MODULE_OBJECT_DEALLOCATE_CALL_NOT_USED
+
+/* DEPRECATION NOTICE
+ * txm_module_object_deallocate() is deprecated and must not be used in new
+ * code.  It is retained only for backward-compatibility with existing modules.
+ *
+ * WHY: when a module calls tx_timer_delete(), tx_semaphore_delete(), or any
+ * other tx_*_delete() service, the Module Manager dispatch layer automatically
+ * releases the associated object pool memory after the kernel cleanup
+ * completes.  No separate deallocation call is required or expected.
+ *
+ * WHAT TO DO: remove any call to txm_module_object_deallocate() from your
+ * module.  The corresponding tx_*_delete() call already handles everything.
+ *
+ * RISK: calling txm_module_object_deallocate() on a live kernel object (one
+ * whose tx_*_delete() has not yet been called) frees the backing pool memory
+ * while the object is still referenced by the kernel, which is undefined
+ * behaviour (use-after-free).
+ */
+#pragma message("txm_module_object_deallocate() is deprecated and must not be used. " \
+                "Call tx_*_delete() instead; the Module Manager dispatch layer " \
+                "releases pool memory automatically on success.")
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */

--- a/common_modules/module_manager/src/txm_module_manager_object_deallocate.c
+++ b/common_modules/module_manager/src/txm_module_manager_object_deallocate.c
@@ -38,7 +38,17 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function deallocates a previously allocated object.            */
+/*    DEPRECATED.  This function is called internally by the Module       */
+/*    Manager dispatch layer after a successful tx_*_delete() call from   */
+/*    a module.  It must not be called directly by module or application  */
+/*    code.  Calling it on a live kernel object (one whose tx_*_delete()  */
+/*    has not yet been called) frees the backing pool memory while the    */
+/*    object is still referenced by the kernel (use-after-free).          */
+/*                                                                        */
+/*    Module authors: remove any explicit call to                         */
+/*    txm_module_object_deallocate().  Calling the appropriate            */
+/*    tx_*_delete() service is sufficient; pool deallocation is handled   */
+/*    automatically by the dispatch layer.                                */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */


### PR DESCRIPTION
## Summary

`txm_module_object_deallocate()` is deprecated. The Module Manager dispatch layer already releases pool memory automatically after every successful `tx_*_delete()` call from a module. There is no scenario in which a module should call `txm_module_object_deallocate()` explicitly.

Calling it on a live kernel object (before the corresponding `tx_*_delete()`) is a use-after-free defect: pool memory is freed while the kernel still holds a reference to the object.

## Changes

### `common_modules/module_lib/src/txm_module_object_deallocate.c`
- Added a prominent deprecation comment block explaining the reason and risk.
- Added a `#pragma message` compile-time warning so that any module that compiles this translation unit receives an explicit notice at build time.

### `common_modules/module_manager/src/txm_module_manager_object_deallocate.c`
- Updated the internal `DESCRIPTION` block to state that this function must not be called directly and that calling it on a live object causes a use-after-free.

## Credit

The use-after-free risk associated with calling `txm_module_object_deallocate()` on a live kernel object was originally identified and reported by @Hack1ll. The report was reviewed and classified as misuse of a deprecated API rather than an exploitable vulnerability, but it prompted this documentation and code hardening effort.

## Companion
Docs update: eclipse-threadx/rtos-docs-asciidoc#32
