### PR TITLE
Add SysTick counter reset in Cortex-M ports

### DIFF
--- a/ports/cortex_m0/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports/cortex_m0/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -111,6 +111,9 @@ _tx_initialize_low_level:
 @    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 @
     LDR     r0, =0xE000E000                         @ Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         @ Reset SysTick Control
+    STR     r1, [r0, #0x18]                         @ Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         @ Setup SysTick Reload Value
     LDR     r1, =0x7                                @ Build SysTick Control Enable Value

--- a/ports/cortex_m23/ac6/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m23/ac6/example_build/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOVW    r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m23/gnu/src/tx_initialize_low_level.S
+++ b/ports/cortex_m23/gnu/src/tx_initialize_low_level.S
@@ -107,6 +107,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOVW    r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m23/iar/src/tx_initialize_low_level.s
+++ b/ports/cortex_m23/iar/src/tx_initialize_low_level.s
@@ -104,6 +104,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m3/ac5/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m3/ac5/example_build/tx_initialize_low_level.s
@@ -162,6 +162,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 ;
     MOV     r0, #0xE000E000                     ; Build address of NVIC registers
+    MOV     r1, #0                              ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                     ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                     ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                     ; Setup SysTick Reload Value
     MOV     r1, #0x7                            ; Build SysTick Control Enable Value

--- a/ports/cortex_m3/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports/cortex_m3/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
 @    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 @
     MOV     r0, #0xE000E000                         @ Build address of NVIC registers
+    MOV     r1, #0                                  @ Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         @ Reset SysTick Control
+    STR     r1, [r0, #0x18]                         @ Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         @ Setup SysTick Reload Value
     MOV     r1, #0x7                                @ Build SysTick Control Enable Value

--- a/ports/cortex_m3/ghs/example_build/tx_initialize_low_level.arm
+++ b/ports/cortex_m3/ghs/example_build/tx_initialize_low_level.arm
@@ -107,6 +107,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
+    MOV     r1, 0                               ; Build value for SysTick reset
+    STR     r1, [r0, 0x10]                      ; Reset SysTick Control
+    STR     r1, [r0, 0x18]                      ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, 0x14]                      ; Setup SysTick Reload Value
     MOV     r1, 0x7                             ; Build SysTick Control Enable Value

--- a/ports/cortex_m3/gnu/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m3/gnu/example_build/tx_initialize_low_level.S
@@ -108,6 +108,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m3/iar/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m3/iar/example_build/tx_initialize_low_level.s
@@ -113,6 +113,9 @@ _tx_initialize_low_level:
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m3/keil/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m3/keil/example_build/tx_initialize_low_level.s
@@ -161,6 +161,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 ;
     MOV     r0, #0xE000E000                     ; Build address of NVIC registers
+    MOV     r1, #0                              ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                     ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                     ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                     ; Setup SysTick Reload Value
     MOV     r1, #0x7                            ; Build SysTick Control Enable Value

--- a/ports/cortex_m33/ac6/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m33/ac6/example_build/tx_initialize_low_level.S
@@ -103,6 +103,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m33/ac6/src/tx_initialize_low_level.S
+++ b/ports/cortex_m33/ac6/src/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m33/gnu/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m33/gnu/example_build/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m33/iar/src/tx_initialize_low_level.s
+++ b/ports/cortex_m33/iar/src/tx_initialize_low_level.s
@@ -108,6 +108,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m4/ac5/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m4/ac5/example_build/tx_initialize_low_level.s
@@ -166,6 +166,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m4/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports/cortex_m4/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
 @    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 @
     MOV     r0, #0xE000E000                         @ Build address of NVIC registers
+    MOV     r1, #0                                  @ Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         @ Reset SysTick Control
+    STR     r1, [r0, #0x18]                         @ Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         @ Setup SysTick Reload Value
     MOV     r1, #0x7                                @ Build SysTick Control Enable Value

--- a/ports/cortex_m4/ghs/example_build/tx_initialize_low_level.arm
+++ b/ports/cortex_m4/ghs/example_build/tx_initialize_low_level.arm
@@ -107,6 +107,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
+    MOV     r1, 0                               ; Build value for SysTick reset
+    STR     r1, [r0, 0x10]                      ; Reset SysTick Control
+    STR     r1, [r0, 0x18]                      ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, 0x14]                      ; Setup SysTick Reload Value
     MOV     r1, 0x7                             ; Build SysTick Control Enable Value

--- a/ports/cortex_m4/gnu/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m4/gnu/example_build/tx_initialize_low_level.S
@@ -118,6 +118,9 @@ _tx_initialize_low_level:
 @    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 @
     MOV     r0, #0xE000E000                         @ Build address of NVIC registers
+    MOV     r1, #0                                  @ Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         @ Reset SysTick Control
+    STR     r1, [r0, #0x18]                         @ Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         @ Setup SysTick Reload Value
     MOV     r1, #0x7                                @ Build SysTick Control Enable Value

--- a/ports/cortex_m4/iar/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m4/iar/example_build/tx_initialize_low_level.s
@@ -113,6 +113,9 @@ _tx_initialize_low_level:
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m4/keil/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m4/keil/example_build/tx_initialize_low_level.s
@@ -181,6 +181,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m55/ac6/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m55/ac6/example_build/tx_initialize_low_level.S
@@ -103,6 +103,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m55/ac6/src/tx_initialize_low_level.S
+++ b/ports/cortex_m55/ac6/src/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m55/gnu/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m55/gnu/example_build/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m55/iar/src/tx_initialize_low_level.s
+++ b/ports/cortex_m55/iar/src/tx_initialize_low_level.s
@@ -108,6 +108,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m7/ac5/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m7/ac5/example_build/tx_initialize_low_level.s
@@ -171,6 +171,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m7/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports/cortex_m7/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
 @    /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 @
     MOV     r0, #0xE000E000                         @ Build address of NVIC registers
+    MOV     r1, #0                                  @ Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         @ Reset SysTick Control
+    STR     r1, [r0, #0x18]                         @ Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         @ Setup SysTick Reload Value
     MOV     r1, #0x7                                @ Build SysTick Control Enable Value

--- a/ports/cortex_m7/ghs/example_build/tx_initialize_low_level.arm
+++ b/ports/cortex_m7/ghs/example_build/tx_initialize_low_level.arm
@@ -107,6 +107,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
+    MOV     r1, 0                               ; Build value for SysTick reset
+    STR     r1, [r0, 0x10]                      ; Reset SysTick Control
+    STR     r1, [r0, 0x18]                      ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, 0x14]                      ; Setup SysTick Reload Value
     MOV     r1, 0x7                             ; Build SysTick Control Enable Value

--- a/ports/cortex_m7/gnu/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m7/gnu/example_build/tx_initialize_low_level.S
@@ -108,6 +108,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m7/iar/example_build/tx_initialize_low_level.s
+++ b/ports/cortex_m7/iar/example_build/tx_initialize_low_level.s
@@ -113,6 +113,9 @@ _tx_initialize_low_level:
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports/cortex_m85/ac6/src/tx_initialize_low_level.S
+++ b/ports/cortex_m85/ac6/src/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m85/gnu/example_build/tx_initialize_low_level.S
+++ b/ports/cortex_m85/gnu/example_build/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports/cortex_m85/iar/src/tx_initialize_low_level.s
+++ b/ports/cortex_m85/iar/src/tx_initialize_low_level.s
@@ -108,6 +108,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_arch/ARMv7-M/threadx/ac5/example_build/tx_initialize_low_level.s
+++ b/ports_arch/ARMv7-M/threadx/ac5/example_build/tx_initialize_low_level.s
@@ -165,6 +165,9 @@ _tx_initialize_low_level
 #ifndef TX_NO_TIMER
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_arch/ARMv7-M/threadx/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports_arch/ARMv7-M/threadx/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -107,6 +107,9 @@ _tx_initialize_low_level:
 #ifndef TX_NO_TIMER
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_arch/ARMv7-M/threadx/ghs/example_build/tx_initialize_low_level.arm
+++ b/ports_arch/ARMv7-M/threadx/ghs/example_build/tx_initialize_low_level.arm
@@ -107,6 +107,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
+    MOV     r1, 0                               ; Build value for SysTick reset
+    STR     r1, [r0, 0x10]                      ; Reset SysTick Control
+    STR     r1, [r0, 0x18]                      ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, 0x14]                      ; Setup SysTick Reload Value
     MOV     r1, 0x7                             ; Build SysTick Control Enable Value

--- a/ports_arch/ARMv7-M/threadx/gnu/example_build/tx_initialize_low_level.S
+++ b/ports_arch/ARMv7-M/threadx/gnu/example_build/tx_initialize_low_level.S
@@ -104,6 +104,9 @@ _tx_initialize_low_level:
 #ifndef TX_NO_TIMER
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_arch/ARMv7-M/threadx/iar/example_build/tx_initialize_low_level.s
+++ b/ports_arch/ARMv7-M/threadx/iar/example_build/tx_initialize_low_level.s
@@ -98,6 +98,9 @@ _tx_initialize_low_level:
 #ifndef TX_NO_TIMER
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_arch/ARMv8-M/threadx/ac6/src/tx_initialize_low_level.S
+++ b/ports_arch/ARMv8-M/threadx/ac6/src/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_arch/ARMv8-M/threadx/gnu/src/tx_initialize_low_level.S
+++ b/ports_arch/ARMv8-M/threadx/gnu/src/tx_initialize_low_level.S
@@ -106,6 +106,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_arch/ARMv8-M/threadx/iar/src/tx_initialize_low_level.s
+++ b/ports_arch/ARMv8-M/threadx/iar/src/tx_initialize_low_level.s
@@ -108,6 +108,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m0+/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports_module/cortex_m0+/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -117,6 +117,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     MOVS    r2, #0x14
     STR     r1, [r0, r2]                         // Setup SysTick Reload Value

--- a/ports_module/cortex_m0+/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
+++ b/ports_module/cortex_m0+/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
@@ -118,6 +118,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     MOVS    r2, #0x14
     STR     r1, [r0, r2]                         // Setup SysTick Reload Value

--- a/ports_module/cortex_m0+/gnu/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports_module/cortex_m0+/gnu/example_build/sample_threadx/tx_initialize_low_level.S
@@ -119,6 +119,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     MOVS    r2, #0x14
     STR     r1, [r0, r2]                         // Setup SysTick Reload Value

--- a/ports_module/cortex_m0+/gnu/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
+++ b/ports_module/cortex_m0+/gnu/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
@@ -119,6 +119,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     MOVS    r2, #0x14
     STR     r1, [r0, r2]                         // Setup SysTick Reload Value

--- a/ports_module/cortex_m0+/iar/example_build/tx_initialize_low_level.s
+++ b/ports_module/cortex_m0+/iar/example_build/tx_initialize_low_level.s
@@ -123,6 +123,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    LDR     r1, =0
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     MOVS    r2, #0x14
     STR     r1, [r0, r2]                         // Setup SysTick Reload Value

--- a/ports_module/cortex_m23/ac6/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m23/ac6/example_build/tx_initialize_low_level.S
@@ -103,6 +103,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOVW    r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m23/gnu/module_manager/src/tx_initialize_low_level.S
+++ b/ports_module/cortex_m23/gnu/module_manager/src/tx_initialize_low_level.S
@@ -105,6 +105,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOVW    r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m23/iar/example_build/tx_initialize_low_level.s
+++ b/ports_module/cortex_m23/iar/example_build/tx_initialize_low_level.s
@@ -104,6 +104,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     LDR     r0, =0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m3/ac5/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m3/ac5/example_build/tx_initialize_low_level.S
@@ -185,6 +185,9 @@ _tx_initialize_low_level
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports_module/cortex_m3/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports_module/cortex_m3/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m3/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
+++ b/ports_module/cortex_m3/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m3/gnu/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m3/gnu/example_build/tx_initialize_low_level.S
@@ -109,6 +109,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
     MOV     r0, #0xE000E000                         @ Build address of NVIC registers
+    MOV     r1, #0                                  @ Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         @ Reset SysTick Control
+    STR     r1, [r0, #0x18]                         @ Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         @ Setup SysTick Reload Value
     MOV     r1, #0x7                                @ Build SysTick Control Enable Value

--- a/ports_module/cortex_m3/iar/example_build/tx_initialize_low_level.s
+++ b/ports_module/cortex_m3/iar/example_build/tx_initialize_low_level.s
@@ -123,6 +123,9 @@ _tx_initialize_low_level:
 ;    /* Configure SysTick.  */
 ;
     MOV     r0, #0xE000E000                         ; Build address of NVIC registers
+    MOV     r1, #0                                  ; Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         ; Reset SysTick Control
+    STR     r1, [r0, #0x18]                         ; Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         ; Setup SysTick Reload Value
     MOV     r1, #0x7                                ; Build SysTick Control Enable Value

--- a/ports_module/cortex_m33/ac6/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m33/ac6/example_build/tx_initialize_low_level.S
@@ -103,6 +103,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m33/gnu/module_manager/src/tx_initialize_low_level.S
+++ b/ports_module/cortex_m33/gnu/module_manager/src/tx_initialize_low_level.S
@@ -103,6 +103,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m33/iar/example_build/tx_initialize_low_level.s
+++ b/ports_module/cortex_m33/iar/example_build/tx_initialize_low_level.s
@@ -104,6 +104,9 @@ _tx_initialize_low_level:
 
     /* Configure SysTick.  */
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m4/ac5/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m4/ac5/example_build/tx_initialize_low_level.S
@@ -171,6 +171,9 @@ _tx_initialize_low_level
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m4/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports_module/cortex_m4/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m4/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
+++ b/ports_module/cortex_m4/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m4/gnu/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m4/gnu/example_build/tx_initialize_low_level.S
@@ -115,6 +115,9 @@ _tx_initialize_low_level:
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m4/iar/example_build/tx_initialize_low_level.s
+++ b/ports_module/cortex_m4/iar/example_build/tx_initialize_low_level.s
@@ -110,6 +110,9 @@ _tx_initialize_low_level:
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m7/ac5/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m7/ac5/example_build/tx_initialize_low_level.S
@@ -171,6 +171,9 @@ _tx_initialize_low_level
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m7/ac6/example_build/sample_threadx/tx_initialize_low_level.S
+++ b/ports_module/cortex_m7/ac6/example_build/sample_threadx/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
     /* Configure SysTick for 100Hz clock, or 16384 cycles if no reference.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m7/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
+++ b/ports_module/cortex_m7/ac6/example_build/sample_threadx_module_manager/tx_initialize_low_level.S
@@ -116,6 +116,9 @@ _tx_initialize_low_level:
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m7/gnu/example_build/tx_initialize_low_level.S
+++ b/ports_module/cortex_m7/gnu/example_build/tx_initialize_low_level.S
@@ -115,6 +115,9 @@ _tx_initialize_low_level:
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value

--- a/ports_module/cortex_m7/iar/example_build/tx_initialize_low_level.s
+++ b/ports_module/cortex_m7/iar/example_build/tx_initialize_low_level.s
@@ -110,6 +110,9 @@ _tx_initialize_low_level:
     /* Configure SysTick.  */
 
     MOV     r0, #0xE000E000                         // Build address of NVIC registers
+    MOV     r1, #0                                  // Build value for SysTick reset
+    STR     r1, [r0, #0x10]                         // Reset SysTick Control
+    STR     r1, [r0, #0x18]                         // Reset SysTick Counter Value
     LDR     r1, =SYSTICK_CYCLES
     STR     r1, [r0, #0x14]                         // Setup SysTick Reload Value
     MOV     r1, #0x7                                // Build SysTick Control Enable Value


### PR DESCRIPTION
The SysTick counter value (NVIC offset 0x18) is indeterminate after reset. Without clearing it prior to enabling the timer, the first tick interval becomes unpredictable.

## PR checklist
<!--- Put an `x` in all the boxes that apply. -->
- [ ] Updated function header with a short description and version number
- [ ] Added test case for bug fix or new feature
- [x ] Validated on real hardware <!-- hardware - toolchain -->