### PR TITLE
Flagged txm_module_object_pointer_get as deprecated

### DIFF
--- a/common_modules/module_lib/src/txm_module_object_pointer_get.c
+++ b/common_modules/module_lib/src/txm_module_object_pointer_get.c
@@ -23,6 +23,22 @@
 #define TXM_MODULE
 #include "txm_module.h"
 #ifndef TXM_MODULE_OBJECT_POINTER_GET_CALL_NOT_USED
+
+/* DEPRECATION NOTICE
+ * txm_module_object_pointer_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: this function passes UINT_MAX as the name-buffer length to the
+ * underlying search. If the name pointer points to a buffer shorter than
+ * the searched string, the comparison can read past the end of the buffer,
+ * which is undefined behaviour.
+ *
+ * WHAT TO DO: replace calls with txm_module_object_pointer_get_extended(),
+ * passing the actual length of the name buffer as the third argument.
+ */
+#pragma message("txm_module_object_pointer_get() is deprecated. " \
+                "Use txm_module_object_pointer_get_extended() and pass " \
+                "the actual name buffer length.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -35,9 +51,10 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function is deprecated and calls the secure version of this    */
-/*    function (_txm_module_manager_object_pointer_get_extended) with the */
-/*    maximum possible name length since none was passed.                 */
+/*    DEPRECATED. Use _txm_module_object_pointer_get_extended() instead,  */
+/*    passing the actual name-buffer length.  This wrapper passes         */
+/*    UINT_MAX as the length, which can cause the name-comparison loop    */
+/*    to read past the end of a short buffer (undefined behaviour).       */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */

--- a/common_modules/module_manager/src/txm_module_manager_object_pointer_get.c
+++ b/common_modules/module_manager/src/txm_module_manager_object_pointer_get.c
@@ -37,9 +37,10 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function is deprecated and calls the secure version of this    */
-/*    function (_txm_module_manager_object_pointer_get_extended) with the */
-/*    maximum possible name length since none was passed.                 */
+/*    DEPRECATED. Use _txm_module_manager_object_pointer_get_extended()   */
+/*    instead, passing the actual name-buffer length.  This wrapper       */
+/*    passes UINT_MAX as the length, which can cause the name-comparison  */
+/*    loop to read past the end of a short buffer (undefined behaviour).  */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */


### PR DESCRIPTION
## Summary
`txm_module_object_pointer_get()` passes `UINT_MAX` as the name-buffer length to the underlying `_extended` search. If `name` points to a buffer shorter than the name being compared, the comparison loop reads past the end of the buffer (undefined behaviour). Callers must use `txm_module_object_pointer_get_extended()` and supply the actual buffer length.

## Changes
- `common_modules/module_lib/src/txm_module_object_pointer_get.c`: prominent deprecation comment block + `#pragma message` compile-time warning.
- `common_modules/module_manager/src/txm_module_manager_object_pointer_get.c`: updated DESCRIPTION block.

## Companion
Docs: eclipse-threadx/rtos-docs-asciidoc#33 (pending)