### PR TITLE
[codex] Fix IAR file lock mutex bounds

### DIFF
--- a/ports/arm11/iar/src/tx_iar.c
+++ b/ports/arm11/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/arm9/iar/src/tx_iar.c
+++ b/ports/arm9/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_a15/iar/src/tx_iar.c
+++ b/ports/cortex_a15/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_a5/iar/src/tx_iar.c
+++ b/ports/cortex_a5/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_a7/iar/src/tx_iar.c
+++ b/ports/cortex_a7/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_a8/iar/src/tx_iar.c
+++ b/ports/cortex_a8/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_a9/iar/src/tx_iar.c
+++ b/ports/cortex_a9/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m0/iar/src/tx_iar.c
+++ b/ports/cortex_m0/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m23/iar/src/tx_iar.c
+++ b/ports/cortex_m23/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m3/iar/src/tx_iar.c
+++ b/ports/cortex_m3/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m33/iar/src/tx_iar.c
+++ b/ports/cortex_m33/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m4/iar/src/tx_iar.c
+++ b/ports/cortex_m4/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m55/iar/src/tx_iar.c
+++ b/ports/cortex_m55/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m7/iar/src/tx_iar.c
+++ b/ports/cortex_m7/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_m85/iar/src/tx_iar.c
+++ b/ports/cortex_m85/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_r4/iar/src/tx_iar.c
+++ b/ports/cortex_r4/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports/cortex_r5/iar/src/tx_iar.c
+++ b/ports/cortex_r5/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_arch/ARMv7-M/threadx/iar/src/tx_iar.c
+++ b/ports_arch/ARMv7-M/threadx/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_arch/ARMv7-M/threadx_modules/iar/module_manager/src/tx_iar.c
+++ b/ports_arch/ARMv7-M/threadx_modules/iar/module_manager/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_arch/ARMv8-M/threadx/iar/src/tx_iar.c
+++ b/ports_arch/ARMv8-M/threadx/iar/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_module/cortex_a7/iar/module_manager/src/tx_iar.c
+++ b/ports_module/cortex_a7/iar/module_manager/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_module/cortex_m0+/iar/module_manager/src/tx_iar.c
+++ b/ports_module/cortex_m0+/iar/module_manager/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_module/cortex_m3/iar/module_manager/src/tx_iar.c
+++ b/ports_module/cortex_m3/iar/module_manager/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_module/cortex_m4/iar/module_manager/src/tx_iar.c
+++ b/ports_module/cortex_m4/iar/module_manager/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_module/cortex_m7/iar/module_manager/src/tx_iar.c
+++ b/ports_module/cortex_m7/iar/module_manager/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */

--- a/ports_module/cortex_r4/iar/module_manager/src/tx_iar.c
+++ b/ports_module/cortex_r4/iar/module_manager/src/tx_iar.c
@@ -270,7 +270,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -287,7 +287,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */
@@ -678,7 +678,7 @@ TX_MUTEX    *mutex_ptr;
         mutex_ptr =  &__tx_iar_file_lock_mutexes[__tx_iar_file_lock_next_free_mutex++];
 
         /* Check for wrap-around on the next free mutex.  */
-        if (__tx_iar_file_lock_next_free_mutex >= _MAX_LOCK)
+        if (__tx_iar_file_lock_next_free_mutex >= _MAX_FLOCK)
         {
 
             /* Yes, set the free index back to 0.  */
@@ -695,7 +695,7 @@ TX_MUTEX    *mutex_ptr;
     }
 
     /* Determine if a free mutex was found.   */
-    if (i >= _MAX_LOCK)
+    if (i >= _MAX_FLOCK)
     {
 
         /* Error!  No more free mutexes!  */


### PR DESCRIPTION
## Summary

- update IAR file lock mutex allocation bounds to use `_MAX_FLOCK`
- keep system lock allocation bounds on `_MAX_LOCK`
- apply the same fix across the duplicated IAR ThreadX port sources

## Root cause

The file lock mutex pool is sized with `_MAX_FLOCK`, but its round-robin allocation checks used `_MAX_LOCK` in two places. When `_MAX_FLOCK` is larger than `_MAX_LOCK`, the allocator can wrap or report exhaustion using the system-lock limit instead of the file-lock pool size.

## Validation

- `git diff --check`
- verified all 26 changed files only replace the file-lock wrap/no-free checks from `_MAX_LOCK` to `_MAX_FLOCK`
- verified no remaining `file_lock` references use `_MAX_LOCK`

## CI notes
- Current required `eclipsefdn/eca` failure says the PR author is not covered by the required Eclipse legal agreements.
- This is an account/legal gate, not a code failure in the IAR file-lock mutex diff.
