### PR TITLE
Made the Cortex-A12, A15 and A17 examples link with an LLVM toolchain

### DIFF
--- a/ports/cortex_a12/gnu/example_build/build_threadx_sample.sh
+++ b/ports/cortex_a12/gnu/example_build/build_threadx_sample.sh
@@ -61,5 +61,5 @@ esac
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a12 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a12 tx_initialize_low_level.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a12 -I../../../../common/inc -I../inc sample_threadx.c
-"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a12 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map tx_initialize_low_level.o sample_threadx.o tx.a
+"${CC}" ${TARGET_FLAGS} -g -nostartfiles -mcpu=cortex-a12 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map crt0.o reset.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/cortex_a12/gnu/example_build/readme.md
+++ b/ports/cortex_a12/gnu/example_build/readme.md
@@ -1,0 +1,30 @@
+# Cortex-A12 GNU example build
+
+This example demonstrates that ThreadX **builds and links** for the Cortex-A12.
+It is not a runnable image.
+
+`tx_initialize_low_level.S` here is the generic ARMv7-A skeleton: it provides
+the interrupt handler shell but programs no interrupt controller and no timer,
+and it does not install a vector table. ThreadX will therefore not receive a
+timer tick on this example, so threads that rely on time slicing or on
+`tx_thread_sleep()` will not run as intended.
+
+For a model targeted example with a GIC, a private timer and a vector table
+installed, see the Cortex-A5, A7, A8 or A9 example builds. Those carry the
+matching support files (`MP_GIC`, `MP_PrivateTimer`, `v7.s`) and target the
+Versatile Express fixed virtual platforms.
+
+## Building
+
+```sh
+./build_threadx.sh          # the ThreadX library, tx.a
+./build_threadx_sample.sh   # the sample image
+```
+
+Set `TOOLCHAIN=atfe` to build with Arm Toolchain for Embedded instead of the
+GNU toolchain:
+
+```sh
+TOOLCHAIN=atfe ATFE_CLANG=/path/to/clang ./build_threadx.sh
+TOOLCHAIN=atfe ATFE_CLANG=/path/to/clang ./build_threadx_sample.sh
+```

--- a/ports/cortex_a15/gnu/example_build/build_threadx_sample.sh
+++ b/ports/cortex_a15/gnu/example_build/build_threadx_sample.sh
@@ -61,5 +61,5 @@ esac
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a15 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a15 tx_initialize_low_level.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a15 -I../../../../common/inc -I../inc sample_threadx.c
-"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a15 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map tx_initialize_low_level.o sample_threadx.o tx.a
+"${CC}" ${TARGET_FLAGS} -g -nostartfiles -mcpu=cortex-a15 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map crt0.o reset.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/cortex_a15/gnu/example_build/readme.md
+++ b/ports/cortex_a15/gnu/example_build/readme.md
@@ -1,0 +1,30 @@
+# Cortex-A15 GNU example build
+
+This example demonstrates that ThreadX **builds and links** for the Cortex-A15.
+It is not a runnable image.
+
+`tx_initialize_low_level.S` here is the generic ARMv7-A skeleton: it provides
+the interrupt handler shell but programs no interrupt controller and no timer,
+and it does not install a vector table. ThreadX will therefore not receive a
+timer tick on this example, so threads that rely on time slicing or on
+`tx_thread_sleep()` will not run as intended.
+
+For a model targeted example with a GIC, a private timer and a vector table
+installed, see the Cortex-A5, A7, A8 or A9 example builds. Those carry the
+matching support files (`MP_GIC`, `MP_PrivateTimer`, `v7.s`) and target the
+Versatile Express fixed virtual platforms.
+
+## Building
+
+```sh
+./build_threadx.sh          # the ThreadX library, tx.a
+./build_threadx_sample.sh   # the sample image
+```
+
+Set `TOOLCHAIN=atfe` to build with Arm Toolchain for Embedded instead of the
+GNU toolchain:
+
+```sh
+TOOLCHAIN=atfe ATFE_CLANG=/path/to/clang ./build_threadx.sh
+TOOLCHAIN=atfe ATFE_CLANG=/path/to/clang ./build_threadx_sample.sh
+```

--- a/ports/cortex_a17/gnu/example_build/build_threadx_sample.sh
+++ b/ports/cortex_a17/gnu/example_build/build_threadx_sample.sh
@@ -61,5 +61,5 @@ esac
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a17 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a17 tx_initialize_low_level.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a17 -I../../../../common/inc -I../inc sample_threadx.c
-"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a17 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map tx_initialize_low_level.o sample_threadx.o tx.a
+"${CC}" ${TARGET_FLAGS} -g -nostartfiles -mcpu=cortex-a17 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map crt0.o reset.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/cortex_a17/gnu/example_build/readme.md
+++ b/ports/cortex_a17/gnu/example_build/readme.md
@@ -1,0 +1,30 @@
+# Cortex-A17 GNU example build
+
+This example demonstrates that ThreadX **builds and links** for the Cortex-A17.
+It is not a runnable image.
+
+`tx_initialize_low_level.S` here is the generic ARMv7-A skeleton: it provides
+the interrupt handler shell but programs no interrupt controller and no timer,
+and it does not install a vector table. ThreadX will therefore not receive a
+timer tick on this example, so threads that rely on time slicing or on
+`tx_thread_sleep()` will not run as intended.
+
+For a model targeted example with a GIC, a private timer and a vector table
+installed, see the Cortex-A5, A7, A8 or A9 example builds. Those carry the
+matching support files (`MP_GIC`, `MP_PrivateTimer`, `v7.s`) and target the
+Versatile Express fixed virtual platforms.
+
+## Building
+
+```sh
+./build_threadx.sh          # the ThreadX library, tx.a
+./build_threadx_sample.sh   # the sample image
+```
+
+Set `TOOLCHAIN=atfe` to build with Arm Toolchain for Embedded instead of the
+GNU toolchain:
+
+```sh
+TOOLCHAIN=atfe ATFE_CLANG=/path/to/clang ./build_threadx.sh
+TOOLCHAIN=atfe ATFE_CLANG=/path/to/clang ./build_threadx_sample.sh
+```

--- a/scripts/check_clang.sh
+++ b/scripts/check_clang.sh
@@ -150,13 +150,7 @@ C_CORES="cortex_m0 cortex_m4 cortex_m23 cortex_m33 cortex_m55 cortex_a7 cortex_a
 # These fail with the GNU toolchain too, so they are not LLVM problems:
 #   arm9 arm11           need newlib multilib variants for those CPUs, which are
 #   cortex_r4 cortex_r5  not present in every GNU toolchain packaging.
-#
-# This one is specific to LLVM:
-#   cortex_a12 a15 a17   their link line omits -nostartfiles, so the toolchain's
-#                        own crt0 is linked, and it needs picolibc's
-#                        __data_start, __data_source, __data_size and __bss_size,
-#                        which the example's linker script does not define.
-EXAMPLES_EXPECTED_TO_FAIL="arm9 arm11 cortex_r4 cortex_r5 cortex_a12 cortex_a15 cortex_a17"
+EXAMPLES_EXPECTED_TO_FAIL="arm9 arm11 cortex_r4 cortex_r5"
 
 failures=0
 skipped=""


### PR DESCRIPTION
Closes the remaining example build gaps for the Cortex-A12, A15 and A17, and documents what those examples are.

## Why they did not link with an LLVM toolchain

Their sample scripts compile `crt0.S` and `reset.S`, name neither on the link line, and omit `-nostartfiles`, leaving the toolchain free to link its own startup as well. Under GNU that produced a working image. Under an LLVM toolchain, picolibc's `crt0` was pulled in and wanted seven symbols the linker script does not define:

```
undefined symbol: __data_start, __data_source, __data_size, __bss_size,
                  __stack, __tls_base, __arm32_tls_tcb_offset
```

Defining picolibc's contract in the shared linker script was tried first and abandoned. The first four are straightforward, but `__arm32_tls_tcb_offset` is an ABI constant that cannot be verified without executing the image, and the whole exercise is unnecessary: **the in-tree `crt0.S` is already a complete startup for this linker script.** It sets up the stack and zeroes BSS between `__bss_start__` and `__bss_end__`, and `.data` carries no `AT()`, so there is nothing to copy.

So the three scripts now pass `-nostartfiles` and name `crt0.o` and `reset.o` — which is what the four sibling A-profile cores already do, and evidently what these scripts were compiling those files for.

### One thing not fully accounted for

Both the old and the new GNU images contain the in-tree startup: `__vectors` from `reset.S` and `_mainCRTStartup` from `crt0.S`, both as defined text symbols. So that startup was already being linked through implicit startup-file resolution rather than an explicit operand. How that happened without the objects being named is not explained here — and that is the argument for naming them. The same implicit behaviour does not hold across toolchains, which is exactly why the LLVM link failed.

## Results

| | before | after |
| --- | --- | --- |
| GNU | ok 41,768 B | **ok 41,276 B** |
| ATfE 22.1.0 | **could not link** | **ok 37,982 B** |

Identical for all three cores. The GNU image is 492 bytes smaller because the unused toolchain startup is no longer linked. The result is structurally sound — entry at `_start`, `__vectors` at address zero, a BSS range in RAM — but it has **not been executed**.

`scripts/check_clang.sh` now links **11 of 11** example builds, leaving only `arm9`, `arm11`, `cortex_r4` and `cortex_r5`, whose failures are newlib multilib packaging rather than defects in the tree.

## What these three examples actually are

Each now carries a readme saying so, because nothing in the tree did:

| | A5, A7, A8, A9 | A12, A15, A17 |
| --- | --- | --- |
| `tx_initialize_low_level.S` | 340–353 lines | **300 lines, identical across all three** |
| Vector table installed | yes, via `MCR p15, 0, r0, c12, c0, 0` | no |
| Interrupt controller programmed | 5 GIC references | **none** |
| Model support files | `MP_GIC`, `MP_PrivateTimer`, `v7.s` | **none** |

The first group are model-targeted examples whose configurations name `FVP_VE_Cortex-A7x1` and similar. The second are the generic ARMv7-A skeleton: they provide the interrupt handler shell but program no interrupt controller and no timer, so **ThreadX receives no timer tick** and anything depending on time slicing or `tx_thread_sleep()` will not behave as intended. They demonstrate that the port builds and links.

Nothing distinguished them before, which invites the assumption that they are equivalent to the A7 example. Making them runnable would need a target to validate against and is better raised separately.
