### PR TITLE
Repaired the garbled description at the top of check_clang.sh

### DIFF
--- a/scripts/check_clang.sh
+++ b/scripts/check_clang.sh
@@ -14,10 +14,10 @@
 # SPDX-License-Identifier: MIT and CC0-1.0
 ##############################################################################
 
-# Builds the Arm ports with an LLVM based toolchain: every assembly source of
-# every Arm gnu port, and the common C sources for one core per architecture
-# profile. Compilation only, no linking, so no target C library is required
-# profile, then links the example builds that have a script driver.
+# Builds the Arm ports with an LLVM based toolchain, in three stages: assemble
+# every assembly source of every Arm gnu port, compile the common C sources for
+# one core per architecture profile, then link the example builds that have a
+# script driver. Only that last stage needs a target C library.
 #
 #     scripts/check_clang.sh                       # clang from PATH
 #     scripts/check_clang.sh --clang /path/to/clang


### PR DESCRIPTION
## Problem

The comment block at the top of `scripts/check_clang.sh` was left half-rewritten
when the example link stage was added to the script. It reads:

```
# Builds the Arm ports with an LLVM based toolchain: every assembly source of
# every Arm gnu port, and the common C sources for one core per architecture
# profile. Compilation only, no linking, so no target C library is required
# profile, then links the example builds that have a script driver.
```

The third line ends mid-clause and `profile` appears twice, the second being the
tail of the sentence that was supposed to be replaced. `--help` prints this
block, so it is user visible rather than an internal comment.

## Change

State the three stages plainly, and keep the point the truncated sentence was
making: of the three, only linking needs a target C library.

```
# Builds the Arm ports with an LLVM based toolchain, in three stages: assemble
# every assembly source of every Arm gnu port, compile the common C sources for
# one core per architecture profile, then link the example builds that have a
# script driver. Only that last stage needs a target C library.
```

Comment only, no behaviour change.

## Verification

`--help` selects these lines by number, so a line count change would have shifted
its output. The replacement is the same four lines, and `--help` was run to
confirm it still frames the description, usage, options and exit status. `bash -n`
passes.