### PR TITLE
Enrolled the Cortex-R52 port in the LLVM C check and exposed the skipped examples

### DIFF
--- a/scripts/check_clang.sh
+++ b/scripts/check_clang.sh
@@ -142,7 +142,12 @@ declare -A PORT_TARGET=(
 # One core per architecture profile for the C sources. Compiling all of them
 # for every core would multiply the run time without adding coverage, since the
 # port headers differ by profile rather than by core.
-C_CORES="cortex_m0 cortex_m4 cortex_m23 cortex_m33 cortex_m55 cortex_a7 cortex_a53 cortex_r5"
+#
+# cortex_r52 earns a slot of its own next to cortex_r5 because Armv8-R AArch32
+# is a separate profile rather than a variant of Armv7-R. That port is written
+# by hand instead of generated from ports_arch, and its tx_port.h differs
+# accordingly, so cortex_r5 does not stand in for it.
+C_CORES="cortex_m0 cortex_m4 cortex_m23 cortex_m33 cortex_m55 cortex_a7 cortex_a53 cortex_r5 cortex_r52"
 
 # Example builds that are not expected to link, with the reason. Named by
 # their port directory, which covers both ports/ and ports_smp/. Listed
@@ -225,12 +230,37 @@ if [ "$no_examples" -eq 0 ]; then
     example_ok=0
     example_total=0
     example_known=""
+    example_nodriver=""
+    example_nosample=""
     for dir in ports/*/gnu/example_build ports_smp/*/gnu/example_build; do
-        [ -f "$dir/build_threadx.sh" ] && [ -f "$dir/build_threadx_sample.sh" ] || continue
+        [ -d "$dir" ] || continue
         core="$(echo "$dir" | cut -d/ -f2)"
+
+        # Anything on the expected-to-fail list is reported before any other
+        # filter is applied, so a name placed there can never drop out of the
+        # output. arm9 and arm11 are the cases that matter: they are Arm ports
+        # with example drivers, but they carry no PORT_TARGET entry, so the
+        # Arm test below would discard them.
         case " $EXAMPLES_EXPECTED_TO_FAIL " in
             *" $core "*) example_known="$example_known $core"; continue ;;
         esac
+
+        # Arm ports only, the same rule the assembly stage applies. Naming
+        # linux or mips32 as a gap here would be noise, not information.
+        [ -n "${PORT_TARGET[$core]:-}" ] || continue
+
+        # A driverless example is not covered by this stage, so say so rather
+        # than dropping out in silence. A port that is simply absent from the
+        # count reads as covered: the CMake based example builds under
+        # ports/cortex_r52 looked like part of the 35 while never being built.
+        if [ ! -f "$dir/build_threadx.sh" ]; then
+            example_nodriver="$example_nodriver $core"
+            continue
+        fi
+        if [ ! -f "$dir/build_threadx_sample.sh" ]; then
+            example_nosample="$example_nosample $core"
+            continue
+        fi
         example_total=$((example_total + 1))
 
         rm -f "$dir"/*.o "$dir"/*.a "$dir"/*.out "$dir"/*.map 2>/dev/null || true
@@ -251,6 +281,12 @@ if [ "$no_examples" -eq 0 ]; then
     say "  $example_ok of $example_total example builds linked"
     if [ -n "$example_known" ]; then
         say "  known not to link, see the list at the top of this script:$example_known"
+    fi
+    if [ -n "$example_nosample" ]; then
+        say "  has build_threadx.sh but no build_threadx_sample.sh, so not linked:$example_nosample"
+    fi
+    if [ -n "$example_nodriver" ]; then
+        say "  no script driver, so outside this stage:$example_nodriver"
     fi
 fi
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Two gaps in `scripts/check_clang.sh`, both of which made the Cortex-R52 port look
better covered than it was.

`C_CORES` gains `cortex_r52`. That list is described as one core per architecture
profile, and Armv8-R AArch32 is a profile rather than a variant of Armv7-R: the
port is written by hand instead of generated from `ports_arch`, so `cortex_r5`
does not stand in for its `tx_port.h`. The assembly was already covered, since
#593 added the `PORT_TARGET` entry, but the common C sources had never been
compiled against that header. They compile clean, 185 of 185.

The example stage skipped any directory lacking both driver scripts, and did so
in silence. A port absent from the count reads as covered, which is how the two
CMake based example builds under `ports/cortex_r52` looked like part of the total
while never being built. The stage now reports what it passed over, in the two
distinct cases that exist. The comment above `EXAMPLES_EXPECTED_TO_FAIL` already
asks for gaps to stay visible; this makes the code agree with it.

That report immediately turned up something: `cortex_m23`, `cortex_m33`,
`cortex_m55` and `cortex_m85` each carry `build_threadx.sh` with no
`build_threadx_sample.sh`, so all four were skipped despite having a driver.
Reported here, not fixed — whether those want a sample script is a separate
question and a separate change.

One ordering detail worth naming, because the first version of this change got it
wrong. The expected-to-fail test now runs *before* the Arm test rather than
after. `arm9` and `arm11` are on that list but carry no `PORT_TARGET` entry, so
testing for Arm first dropped them from the report entirely, reintroducing the
same silence for two ports that were already being named.

Verified with Arm Toolchain for Embedded 22.1.0, the version the workflow pins:
711 of 711 assembly sources, 185 of 185 common C sources for each of the nine
cores including `cortex_r52`, and 38 of 38 example builds linking, so the built
set is unchanged by this commit. The remaining driverless ports report as
`cortex_r52`, `cortex_a5_smp`, `cortex_a7_smp` and `cortex_a9_smp` — the three A
profile SMP ports have no example scripts, and the R52 examples are driven by
CMake. Giving those genuine LLVM coverage needs an ATfE CMake toolchain file and
is being looked at separately. `--help` still frames the intended lines, since
the additions sit below the range it selects by number. `bash -n` passes, and
`scripts/check_ports.sh` is unaffected and still green.
