### PR TITLE
Made the ARMv8-A debug launch configurations name their own core

### DIFF
--- a/ports/cortex_a34/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a34/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A34x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a34x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A34x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a34/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a34/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A34x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a34x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a53/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a53/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A53x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a53x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A53x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a53/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a53/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A53x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a53x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a55/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a55/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A55x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a55x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A55x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a55/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a55/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A55x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a55x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a57/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a57/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A57x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a57x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A57x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a57/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a57/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A57x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a57x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a65/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a65/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A65x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a65x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A65x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a65/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a65/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A65x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a65x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a65ae/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a65ae/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A65AEx1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a65aex1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A65AEx1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a65ae/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a65ae/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A65AEx1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a65aex1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a72/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a72/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A72x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a72x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A72x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a72/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a72/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A72x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a72x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a73/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a73/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A73x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a73x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A73x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a73/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a73/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A73x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a73x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a75/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a75/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A75x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a75x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A75x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a75/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a75/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A75x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a75x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a76/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a76/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A76x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a76x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A76x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a76/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a76/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A76x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a76x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a76ae/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a76ae/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A76AEx1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a76aex1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A76AEx1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a76ae/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a76ae/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A76AEx1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a76aex1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports/cortex_a77/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a77/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -232,7 +232,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A77x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a77x1"/>
     <stringAttribute key="config_file" value="CDB://../../Arm FVP/Base_A77x1/iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports/cortex_a77/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports/cortex_a77/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -239,7 +239,7 @@
     <stringAttribute key="config_db_platform_name" value="Arm FVP (Installed with Arm DS) - Base_A77x1"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a35x1"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp_installedwitharmds_/base_a77x1"/>
     <stringAttribute key="config_file" value="CDB://cadi_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <listAttribute key="debugger.view.DisassemblyView:current">

--- a/ports_arch/ARMv8-A/update.ps1
+++ b/ports_arch/ARMv8-A/update.ps1
@@ -94,17 +94,26 @@ $patches = (
         (('value="cortex-a35"'), ('value="cortex-$($core_short_lower)"')),
         (('Cortex-A35.AArch64.ARMv8.Neon.Crypto'), ('Cortex-$($core_short_upper).AArch64.ARMv8.Neon.Crypto'))
     )),
+    # The base_a35x<n> entries are the config database taxonomy id, which is
+    # spelt in lower case in the launch files. They used to read base_A35x<n>,
+    # which -creplace never matched, leaving every port pointing at the A35
+    # platform. The Cortex-A35x<n> SMP entries are the activity name the SMP
+    # launch files use in place of "Debug Cortex-A35"; matching the " SMP"
+    # suffix keeps them from also rewriting the FVP model name.
     ('example_build\sample_threadx\sample_threadx.launch', (
         ('Debug Cortex-A35', 'Debug Cortex-$($core_short_upper)'),
         ('Base_A35x1', 'Base_$($core_short_upper)x1'),
-        ('base_A35x1', 'base_$($core_short_lower)x1'),
+        ('base_a35x1', 'base_$($core_short_lower)x1'),
         ('FVP_Base_Cortex-A35x1', 'FVP_Base_Cortex-$($core_short_upper)x1'),
+        ('Cortex-A35x1 SMP', 'Cortex-$($core_short_upper)x1 SMP'),
         ('Base_A35x2', 'Base_$($core_short_upper)x2'),
-        ('base_A35x2', 'base_$($core_short_lower)x2'),
+        ('base_a35x2', 'base_$($core_short_lower)x2'),
         ('FVP_Base_Cortex-A35x2', 'FVP_Base_Cortex-$($core_short_upper)x2'),
+        ('Cortex-A35x2 SMP', 'Cortex-$($core_short_upper)x2 SMP'),
         ('Base_A35x4', 'Base_$($core_short_upper)x4'),
-        ('base_A35x4', 'base_$($core_short_lower)x4'),
-        ('FVP_Base_Cortex-A35x4', 'FVP_Base_Cortex-$($core_short_upper)x4')
+        ('base_a35x4', 'base_$($core_short_lower)x4'),
+        ('FVP_Base_Cortex-A35x4', 'FVP_Base_Cortex-$($core_short_upper)x4'),
+        ('Cortex-A35x4 SMP', 'Cortex-$($core_short_upper)x4 SMP')
     ))
 )
 

--- a/ports_arch/ARMv8-A/update.sh
+++ b/ports_arch/ARMv8-A/update.sh
@@ -169,8 +169,19 @@ for port_set in ${port_sets}; do
                 patch_file "${launch}" 'Debug Cortex-A35' "Debug Cortex-${core_short_upper}"
                 for count in 1 2 4; do
                     patch_file "${launch}" "Base_A35x${count}"             "Base_${core_short_upper}x${count}"
-                    patch_file "${launch}" "base_A35x${count}"             "base_${core_short_lower}x${count}"
+                    # The config database taxonomy id is spelt in lower case in
+                    # the launch files, so the search string must be too. It
+                    # used to read base_A35x, which matched nothing and left
+                    # every port pointing at the A35 platform. The ARMv7-A
+                    # generator gets this right, which is why its ports carry a
+                    # per-core ve_cortex_a<n>x1 id.
+                    patch_file "${launch}" "base_a35x${count}"             "base_${core_short_lower}x${count}"
                     patch_file "${launch}" "FVP_Base_Cortex-A35x${count}"  "FVP_Base_Cortex-${core_short_upper}x${count}"
+                    # The SMP launch files name the activity "Cortex-A35x4 SMP"
+                    # rather than "Debug Cortex-A35", so the rule above does not
+                    # reach them. Match the " SMP" suffix so this cannot also
+                    # rewrite the FVP model name handled on the line above.
+                    patch_file "${launch}" "Cortex-A35x${count} SMP"       "Cortex-${core_short_upper}x${count} SMP"
                 done
             fi
         done

--- a/ports_smp/cortex_a34_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a34_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A34x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A34x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a34x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a34_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a34_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A34x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A34x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a34x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a53_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a53_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A53x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A53x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a53x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a53_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a53_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A53x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A53x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a53x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a55_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a55_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A55x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A55x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a55x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a55_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a55_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A55x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A55x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a55x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a57_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a57_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A57x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A57x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a57x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a57_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a57_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A57x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A57x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a57x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a65_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a65_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A65x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A65x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a65x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a65_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a65_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A65x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A65x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a65x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a65ae_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a65ae_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A65AEx4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A65AEx4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a65aex4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a65ae_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a65ae_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A65AEx4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A65AEx4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a65aex4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a72_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a72_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A72x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A72x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a72x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a72_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a72_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A72x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A72x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a72x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a73_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a73_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A73x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A73x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a73x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a73_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a73_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A73x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A73x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a73x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a75_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a75_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A75x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A75x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a75x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a75_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a75_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A75x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A75x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a75x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a76_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a76_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A76x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A76x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a76x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a76_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a76_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A76x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A76x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a76x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a76ae_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a76ae_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A76AEx4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A76AEx4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a76aex4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a76ae_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a76ae_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A76AEx4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A76AEx4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a76aex4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a77_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a77_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A77x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A77x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a77x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a77_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a77_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A77x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A77x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a77x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a78_smp/ac6/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a78_smp/ac6/example_build/sample_threadx/sample_threadx.launch
@@ -316,13 +316,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A78x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A78x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a78x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>

--- a/ports_smp/cortex_a78_smp/gnu/example_build/sample_threadx/sample_threadx.launch
+++ b/ports_smp/cortex_a78_smp/gnu/example_build/sample_threadx/sample_threadx.launch
@@ -345,13 +345,13 @@
     <listAttribute key="com.arm.debugger.views.common.AddressTracker.debugger.view.DisassemblyView.ranges">
         <listEntry value="100"/>
     </listAttribute>
-    <stringAttribute key="config_db_activity_name" value="Cortex-A35x4 SMP"/>
+    <stringAttribute key="config_db_activity_name" value="Cortex-A78x4 SMP"/>
     <stringAttribute key="config_db_connection_keys" value="dtsl_config dtsl_tracecapture_option connect_existing_model dtsl_config_script model_params model_iris config_file model_connection_address setup TCP_KILL_ON_EXIT TCP_DISABLE_EXTENDED_MODE"/>
     <stringAttribute key="config_db_connection_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A78x4"/>
     <stringAttribute key="config_db_project_type" value="Bare Metal Debug"/>
     <stringAttribute key="config_db_project_type_id" value="BARE_METAL"/>
-    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
+    <stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a78x4"/>
     <stringAttribute key="config_file" value="CDB://iris_config.xml"/>
     <booleanAttribute key="connectOnly" value="false"/>
     <stringAttribute key="connect_existing_model" value="false"/>


### PR DESCRIPTION
## Problem

Two identifiers in the Arm Development Studio launch configurations still said
A35 in every AArch64 port, because the ARMv8-A generator's patch table could not
reach them.

**The config database taxonomy id, in all 25 ports.** It is spelt in lower case
in the launch files:

```xml
<stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
```

but the patch rule searched for `base_A35x4`. Both generators are case sensitive
at that point — `sed` in `update.sh`, `-creplace` in `update.ps1` — so the rule
matched nothing and every port kept the A35 taxonomy id while the platform name
and the model name beside it already named the correct core:

```xml
<stringAttribute key="config_db_platform_name" value="Arm FVP - Base_A77x4"/>
<stringAttribute key="config_db_taxonomy_id" value="/platform/armfvp/base_a35x4"/>
<listEntry value="&quot;FVP_Base_Cortex-A77x4&quot;"/>
```

Two independent signs that substitution was intended: the rule exists at all,
and the ARMv7-A generator does the same job correctly, which is why its ports
have shipped per-core ids — `ve_cortex_a12x1`, `ve_cortex_a15x1` and so on —
all along.

**The activity name, in all 13 SMP ports.** The SMP launch files use
`Cortex-A35x4 SMP` where the ThreadX ones use `Debug Cortex-A35`, so the
existing `Debug Cortex-A35` rule reached the ThreadX ports only and every SMP
port advertised an A35 activity.

## Change

Correct the taxonomy search string to lower case, and add a rule for the SMP
activity name. The new rule matches the ` SMP` suffix so that it cannot also
rewrite the `FVP_Base_Cortex-A35x<n>` model name that the preceding rule handles.
Mirrored in `update.ps1`, which is kept equivalent to `update.sh`.

## Verification

Regenerating changes 50 launch files and nothing else. Every changed line is one
of the two intended attributes and no other:

| attribute | lines | files |
|---|---|---|
| `config_db_taxonomy_id` | 100 | 24 ThreadX + 26 SMP |
| `config_db_activity_name` | 52 | 26 SMP |

No `program_arguments` or model-name line moves, which confirms the new ` SMP`
rule stays clear of the model name. The two Cortex-A35 ports are untouched, as
they must be, since substituting A35 for A35 is a no-op.

`scripts/check_ports.sh` passes, so the result is reproducible.
`scripts/check_clang.sh` passes at 42 of 42 example builds, unchanged — these
files are not part of any build.

**What cannot be checked here:** confirming that Arm Development Studio resolves
the per-core taxonomy ids needs Arm Development Studio. The change rests on the
platform name and model already naming the core, on the patch rule's existence,
and on the ARMv7-A ports having carried per-core ids for years.

## A separate problem in the same files

Worth a follow-up, deliberately not folded in here because it is a different
kind of defect and touches ARMv7-A as well: the launch templates in `ports_arch`
carry saved IDE session state from the machines they were last debugged on.

- A `scripts_view_script_links` map whose keys are absolute paths such as
  `C:\Users\<name>\...\ports\cortex_a35\ac6\example_build\sample_threadx\use_model_semihosting.ds`.
  70 launch files carry these, naming three different developers' home
  directories; a further 53 files carry the macOS `/Users/<name>/...` equivalent.
  The script the launch actually uses is referenced portably one line earlier,
  through `${workspace_loc:/sample_threadx/use_model_semihosting.ds}`, so this
  map looks like a stale convenience cache rather than something load-bearing.
- A `breakpoints` attribute holding six saved breakpoints anchored to paths
  under `cortex_a35`, copied into every port, where they cannot resolve.

Neither is a substitution the generator missed — they are session state that
should probably not be in a shipped template at all, which is a judgement worth
making on its own.
