### PR TITLE
Added TX_ENABLE_FIQ_SUPPORT to the feature-macro assembly stage

### DIFF
--- a/scripts/check_clang.sh
+++ b/scripts/check_clang.sh
@@ -149,7 +149,14 @@ declare -A PORT_TARGET=(
 # and Cortex-M23 execution-profile paths: invalid on Armv6-M and Armv8-M
 # Baseline, where the 16-bit POP takes r0-r7 and pc only, and rejected by GNU as
 # well as by LLVM. Turning the feature on had never once been tried.
-FEATURE_MACROS="TX_ENABLE_VFP_SUPPORT TX_LOW_POWER TX_ENABLE_EXECUTION_CHANGE_NOTIFY"
+FEATURE_MACROS="TX_ENABLE_VFP_SUPPORT TX_ENABLE_FIQ_SUPPORT TX_LOW_POWER
+                TX_ENABLE_EXECUTION_CHANGE_NOTIFY"
+
+# TX_ENABLE_IRQ_NESTING and TX_ENABLE_FIQ_NESTING are deliberately not here.
+# They guard no assembly in the trees this script walks: the nesting start and end
+# routines are separate files compiled unconditionally, and the macros only feed
+# the TX_PORT_SPECIFIC_BUILD_OPTIONS bitfield in tx_port.h. Adding them would
+# assemble nothing new and imply coverage that does not exist.
 
 # Extra flags for the VFP paths, per core, needed only where -mcpu alone cannot
 # assemble them. Cortex-R4's FPU is an option rather than part of the core, so


### PR DESCRIPTION
#608 assembled the code behind `TX_ENABLE_VFP_SUPPORT`, `TX_LOW_POWER` and
`TX_ENABLE_EXECUTION_CHANGE_NOTIFY`, and missed `TX_ENABLE_FIQ_SUPPORT`, which
guards assembly in **145 files** across the A and R profile ports.

All 145 assemble today, so this adds no fix — only the regression protection the
other three already have. It is the same argument as #608: a guarded path that
nothing assembles is a path where the next `.arch`-class mistake waits.

It also records why `TX_ENABLE_IRQ_NESTING` and `TX_ENABLE_FIQ_NESTING` are *not*
in the list, since their absence otherwise reads as the same oversight I am fixing
here. They guard no assembly in the trees this script walks: the nesting start and
end routines are separate files compiled unconditionally, and the macros only feed
the `TX_PORT_SPECIFIC_BUILD_OPTIONS` bitfield in `tx_port.h`. Adding them would
assemble nothing new while implying coverage that does not exist.

Verified with Arm Toolchain for Embedded 22.1.0:

```
== Assembly sources of every Arm gnu port ==
  711 of 711 assembled
== Assembly behind feature macros ==
  TX_ENABLE_VFP_SUPPORT: 37 of 37 assembled
  TX_ENABLE_FIQ_SUPPORT: 145 of 145 assembled
  TX_LOW_POWER: 8 of 8 assembled
  TX_ENABLE_EXECUTION_CHANGE_NOTIFY: 218 of 218 assembled
```
