### PR TITLE
Made the basic processing counter visible to the reporting thread

### DIFF
--- a/utility/benchmarks/thread_metric/tm_basic_processing_test.c
+++ b/utility/benchmarks/thread_metric/tm_basic_processing_test.c
@@ -41,7 +41,13 @@
 
 /* Define the counters used in the demo application...  */
 
-unsigned long   tm_basic_processing_counter;
+/* volatile because the reporting thread reads this while the processing thread
+   below increments it. The processing loop calls nothing, so without volatile
+   the compiler is free to keep the counter in a register for the lifetime of an
+   infinite loop and never write it back: at -O2 it does exactly that, and the
+   report reads 0 forever.  */
+
+volatile unsigned long   tm_basic_processing_counter;
 
 
 /* Test array.  We will just do a series of calculations on the
@@ -98,7 +104,8 @@ void  tm_basic_processing_initialize(void)
 void  tm_basic_processing_thread_0_entry(void)
 {
 
-int     i;
+int             i;
+unsigned long   snapshot;
 
     /* Initialize the test array.   */
     for (i = 0; i < 1024; i++)
@@ -111,6 +118,15 @@ int     i;
     while(1)
     {
 
+        /* Read the counter once per pass and use the copy in the loop below.
+           Reading the volatile counter inside the loop instead would add a
+           memory access to every one of the 1024 iterations and so change the
+           amount of work this test performs. That matters more here than
+           elsewhere in the suite: this test is the baseline the other results
+           are scaled against, so its throughput has to stay comparable with
+           previously published figures and with other RTOSes.  */
+        snapshot =  tm_basic_processing_counter;
+
         /* Loop through the basic processing array, add the previous
            contents with the contents of the tm_basic_processing_counter
            and xor the result with the previous value...   just to eat
@@ -119,11 +135,11 @@ int     i;
         {
 
             /* Update each array entry.  */
-            tm_basic_processing_array[i] =  (tm_basic_processing_array[i] + tm_basic_processing_counter) ^ tm_basic_processing_array[i];
+            tm_basic_processing_array[i] =  (tm_basic_processing_array[i] + snapshot) ^ tm_basic_processing_array[i];
         }
 
         /* Increment the basic processing counter.  */
-        tm_basic_processing_counter++;
+        tm_basic_processing_counter =  snapshot + 1;
     }
 }
 


### PR DESCRIPTION
## Problem

The thread-metric basic processing test reports `Time Period Total: 0` for every
period when built with optimisation, and on top of that prints
`ERROR: Invalid counter value(s). Basic processing thread died!` — the counter
never differs from the previous reading, so the liveness check misfires too.

`tm_basic_processing_counter` is written by the processing thread and read by the
reporting thread, but it was a plain global. The processing loop calls nothing, so
nothing forces the compiler to write the counter back to memory, and in an
infinite loop there is no exit path where it would have to. At `-O2` with
`arm-none-eabi-gcc 13.2.1` the counter is loaded once, incremented in a register,
and never stored:

```
  28:  ldr  ip, [r3]        <- counter loaded once, before the loop
  30:  ...                  <- inner loop over the volatile array
  50:  add  ip, ip, #1      <- increment stays in the register
  54:  b    2c              <- and around again
```

There is no store to the counter anywhere, so the reporting thread reads a
location that stays 0 for the life of the program.

**This is not specific to the Armv8-R target it was reported on.** The same shape
appears for Cortex-M4 in Thumb state, and at `-O1`, `-O2`, `-O3` and `-Os`. Only
`-O0` happens to work, because there the counter is spilled after every
statement.

The array was already `volatile`, which is why the arithmetic itself survives
optimisation. Only the counter was missing.

## Change

Declare the counter `volatile`, and read it into a local once per pass so the
1024-iteration loop uses the local:

```c
volatile unsigned long   tm_basic_processing_counter;
...
    while(1)
    {
        snapshot =  tm_basic_processing_counter;

        for (i = 0; i < 1024; i++)
        {
            tm_basic_processing_array[i] =  (tm_basic_processing_array[i] + snapshot) ^ tm_basic_processing_array[i];
        }

        tm_basic_processing_counter =  snapshot + 1;
    }
```

The snapshot is the part that matters beyond correctness. Marking the counter
`volatile` and leaving it in the loop expression moves a memory read *inside* the
loop — 3 loads per element instead of 2, 9 instructions instead of 8 — which
changes how much work the test performs. The readme is explicit that this test is
the reference the rest of the suite is scaled against:

> This is the baseline test consisting of a single thread. This should execute the
> same on every operating system. Test values from testing with different RTOS
> products should be scaled relative to the difference between the values of this
> test.

So a change in its throughput rescales every cross-RTOS comparison the suite
produces and breaks comparability with previously published figures. The snapshot
keeps the measured loop exactly as it is today.

`volatile` is the right primitive rather than an atomic: single writer, single
reader, naturally aligned 32-bit word, and the reporting thread needs only
eventual visibility, not ordering against other data.

## Verification

By disassembly, not inspection. After the change the inner loop is
instruction-for-instruction identical to what `dev` generates today —
`ldr/ldr/add/eor/str/add/cmp/bne` — with one volatile read hoisted above it and
one store below:

```
  30:  ldr  ip, [lr]              one read per pass; the back edge targets 34,
  34:  ldr  r2, [r1,r3,lsl #2]    so this sits outside the loop
  38:  ldr  r0, [r1,r3,lsl #2]
  3c:  add  r2, r2, ip
  40:  eor  r2, r2, r0
  44:  str  r2, [r1,r3,lsl #2]
  48:  add  r3, r3, #1
  4c:  cmp  r3, #1024
  50:  bne  34
  54:  add  ip, ip, #1
  58:  str  ip, [lr]        <- the counter is now published
  5c:  b    2c
```

Confirmed for `cortex-r52` in Arm state and `cortex-m4` in Thumb state, with
`arm-none-eabi-gcc 13.2.1 20231009` — the version in the report.

## Scope: the rest of the suite is not affected

Every other test shares counters between a worker and the reporting thread
without `volatile` too, so I checked each one. They are safe, and for a reason
worth writing down: their loops all call into the porting layer, and the compiler
cannot prove the callee leaves the global alone, so it spills the counter around
the call.

| test | worker loop contains | counter stored? |
|---|---|---|
| basic_processing | pure computation, no calls | **no — this bug** |
| cooperative / preemptive | `tm_thread_relinquish` | yes |
| synchronization | `tm_semaphore_get` / `put` | yes |
| message_processing | `tm_queue_send` / `receive` | yes |
| memory_allocation | `tm_memory_pool_allocate` / `deallocate` | yes |
| interrupt, interrupt_preemption | handler returns; `tm_interrupt_generate` | yes |

The cooperative worker, for example, compiles to
`bl tm_thread_relinquish; ldr r3,[r4]; add r3,#1; str r3,[r4]` — the call forces
the store. So this needs no sweeping change. Adding `volatile` to the others would
be defensible on principle, but it would change generated code for no behavioural
gain, and in a benchmark that is not free.

Reported by @hotislandn in #480, which identified the cause correctly.
