### PR TITLE
Enabled ATCM on S32Z280, and left the other two banks off for a measured reason

### DIFF
--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
@@ -398,6 +398,78 @@ void bsp_main(void)
         linflexd_putc('\n');
     }
 
+    /* --- TCM: enable, preload, prove ------------------------------------
+       Done before the MPU goes on, so a failure here is not confused with a
+       missing MPU region.  The preload is not optional: ECC is enabled on this
+       part, so a location read before it has been written reports an error, and
+       that error would look exactly like an inaccessible TCM.  */
+
+    MARK(0x20);
+    linflexd_puts("T2 TCM state as entry.S left it\n");
+    {
+        static const char *const bank_name[3] = { "ATCM", "BTCM", "CTCM" };
+        unsigned int i;
+        unsigned int atcm_ok;
+
+        /* Verification only.  Nothing is programmed here: ENABLEEL2 is ignored
+           when written from EL1, so TCM setup belongs at EL2 in entry.S, and
+           calling tcm_enable() from here would additionally switch on the banks
+           entry.S deliberately leaves off.  */
+
+        for (i = 0U; i < 3U; i++)
+        {
+            tcm_bank_t bank;
+
+            tcm_read_bank(i, &bank);
+
+            linflexd_puts(bank_name[i]);
+            linflexd_puts(" base=0x");
+            linflexd_put_hex32((unsigned int) bank.base);
+            linflexd_puts(" en2=");
+            linflexd_putc((char) ('0' + (char) bank.enable_el2));
+            linflexd_puts(" en10=");
+            linflexd_putc((char) ('0' + (char) bank.enable_el10));
+            linflexd_puts((bank.enable_el10 != 0U)
+                              ? "  enabled\n"
+                              : "  off on purpose, see entry.S\n");
+        }
+
+        tcm_read_bank(0U, &(tcm_bank_t){0});
+        {
+            tcm_bank_t atcm;
+
+            tcm_read_bank(0U, &atcm);
+            atcm_ok = ((atcm.base == S32Z_ATCM_BASE) &&
+                       (atcm.enable_el2 != 0U) && (atcm.enable_el10 != 0U)) ? 1U : 0U;
+        }
+
+        if (atcm_ok != 0U)
+        {
+            MARK(0x21);
+            linflexd_puts("T3 preloading ATCM to establish ECC check bits\n");
+            tcm_preload(0U, S32Z_ATCM_BASE, S32Z_ATCM_SIZE);
+
+            MARK(0x22);
+            linflexd_puts("T4 write and read back ATCM\n");
+            {
+                volatile unsigned int *first = (volatile unsigned int *) S32Z_ATCM_BASE;
+                volatile unsigned int *last  =
+                    (volatile unsigned int *) (S32Z_ATCM_BASE + S32Z_ATCM_SIZE - 4UL);
+
+                *first = 0xA5A5A5A5U;
+                *last  = 0x5A5A5A5AU;
+
+                linflexd_puts(((*first == 0xA5A5A5A5U) && (*last == 0x5A5A5A5AU))
+                                  ? "ATCM PASS first and last word hold\n"
+                                  : "ATCM FAIL readback mismatch\n");
+            }
+        }
+        else
+        {
+            linflexd_puts("T3 skipped: ATCM is not enabled as expected\n");
+        }
+    }
+
     /* --- MPU, then the GIC ------------------------------------------------
        The GIC needs its region mapped Device nGnRnE (Cortex-R52 TRM), which
        needs the MPU on.  Markers around the enable: if the console survives it,
@@ -452,6 +524,43 @@ void bsp_main(void)
         report("GICR_PIDR2", *(volatile unsigned int *)(S32Z_GIC_BASE + 0x10FFE8UL));
         MARK(0x16);
         linflexd_puts("M4 GIC reachable\n");
+
+        /* TCM again, now that the MPU is enforcing.  The TRM requires an MPU
+           region per TCM before it can be used, so this is the check that those
+           three regions are right -- an enabled TCM with no region faults here
+           and nowhere earlier.  */
+
+        MARK(0x23);
+        linflexd_puts("T5 ATCM still reachable with the MPU on\n");
+        {
+            volatile unsigned int *p = (volatile unsigned int *) S32Z_ATCM_BASE;
+            tcm_bank_t  atcm;
+            unsigned int answers;
+
+            tcm_read_bank(0U, &atcm);
+
+            *p = 0x5A5A0000U;
+            answers = (*p == 0x5A5A0000U) ? 1U : 0U;
+
+            /* Both halves matter.  A disabled TCM's range is serviced through
+               AXIM, so memory answering there says nothing about the TCM: an
+               earlier version of this check reported every bank accessible while
+               two of them were disabled.  */
+
+            if ((answers != 0U) && (atcm.enable_el10 != 0U))
+            {
+                linflexd_puts("ATCM PASS enabled and holding data under MPU\n");
+            }
+            else if (answers != 0U)
+            {
+                linflexd_puts("ATCM NOT TCM: address answers but the bank is\n"
+                              "     disabled, so this is AXIM behind it\n");
+            }
+            else
+            {
+                linflexd_puts("ATCM FAIL address does not answer\n");
+            }
+        }
 
         /* --- interrupts -------------------------------------------------
            Bring up the GIC properly, enable the timer PPI, arm a 10 ms

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/entry.S
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/entry.S
@@ -235,6 +235,65 @@ start_a32:
     mcr     p15, 4, r0, c1, c1, 0
     isb
 
+    /* TCM: program the bases and enable all three banks, here at EL2.
+     *
+     * This is at EL2 deliberately.  Writing ENABLEEL10 from EL1 works, but
+     * ENABLEEL2 is silently ignored there -- measured, on both BTCM and CTCM:
+     * the base took and bit 0 took while bit 1 stayed clear.  The TRM does not
+     * say so outright, but EL1 being unable to change what EL2 can see is the
+     * sensible reading, and doing the whole job at EL2 avoids the question.
+     *
+     * ATCM boots enabled at address 0 because CFGTCMBOOTx is tied high here, so
+     * this also moves it off zero, which makes a null-pointer write fault rather
+     * than quietly land in tightly-coupled memory.  Each base must be
+     * size-aligned (TRM r1p3 6.2); 64KB at 0x30000000 and 16KB at 0x30100000
+     * and 0x30200000 satisfy that.
+     *
+     * SIZE and WAITSTATES are read-only descriptions of the hardware, so the
+     * values written here keep the bits the banks already report: ATCM 64KB with
+     * one wait state, BTCM 16KB with none, CTCM 16KB with one.
+     *
+     * Nothing may READ the TCMs after this until they have been written, because
+     * ECC is enabled on this part and the check bits are not initialised by the
+     * core (TRM 6.2.2).  bsp_main preloads them.
+     */
+
+    ldr     r0, =(0x30000000 | (0x07 << 2) | (1 << 8) | (1 << 1) | (1 << 0))
+    mcr     p15, 0, r0, c9, c1, 0           /* IMP_ATCMREGIONR              */
+    /* BTCM and CTCM are deliberately NOT enabled, and this costs nothing that
+     * matters: the reference manual describes TCM_A as the bank "optimized for
+     * small, regularly executed code such as interrupt service routines or OS
+     * kernels", which is what a TCM is wanted for here.
+     *
+     * Enabling a second bank on this part removes all measurable data-cache
+     * benefit.  Measured, five configurations, one variable:
+     *
+     *   ATCM only                      cache gain 24%
+     *   ATCM + BTCM                    cache gain  0%
+     *   ATCM + BTCM + CTCM             cache gain  0%
+     *   ATCM + BTCM at another base    cache gain  0%
+     *   ATCM + CTCM, BTCM disabled     cache gain  0%
+     *
+     * So it is not a particular bank, not the bank's address, and not the ECC
+     * preload -- it is enabling a second bank at all.  The benchmark buffer sits
+     * in non-RTU-local SRAM at 0x31800000, outside every TCM window, and the
+     * cache still reports 16KB with 4 ways and 64 sets throughout.
+     *
+     * No erratum covers it.  Checked the Cortex-R52 errata notice
+     * (SDEN-857344 issue 19, all 25 entries) and the S32Z2 mask set errata for
+     * 0P91J; the RTU and R52 entries there are ERR050509, ERR051107, ERR051153,
+     * ERR051441, ERR051613, ERR051614 and ERR052126, none of which describes
+     * this.  A shared RAM pool between the LLC and the TCMs would explain it,
+     * since the RTU has a last-level cache that "allocates ways to specific
+     * domains", but that is a guess and it is NXP's to confirm.
+     *
+     * Enabling them is one uncommented line each if that answer arrives.  Until
+     * then, shipping them would trade a 24% cache regression for TCM this
+     * example does not use.
+     */
+
+    isb
+
     /* Let EL1 reach the FPU: clear HCPTR.TCP10/TCP11.  The R52 always has at
        least a single-precision FPU, so this matters even for a soft-float
        kernel if application code uses it.  */

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/mpu.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/mpu.c
@@ -352,7 +352,34 @@ static void build_table(void)
     mpu_regions[5].mpu_region_attr_index    = MPU_ATTR_NORMAL_WB;
     mpu_regions[5].mpu_region_name          = "ext   RW NX normal-wb";
 
-    mpu_regions_used = 6U;
+    /* One region per TCM bank.  The TRM is explicit that an enabled TCM still
+       needs an MPU region before it can be used, and that an enabled TCM always
+       behaves as Non-cacheable Non-shareable Normal memory whatever attributes
+       the MPU carries -- so the attribute index below does not describe the TCM,
+       only the permissions do.  Kept as three regions rather than one spanning
+       0x30000000 to 0x30203FFF, because a single region would also make the
+       1MB gaps between banks accessible, and those are not TCM.
+
+       Left executable on purpose: the point of TCM is deterministic access for
+       code as much as data, so an image that wants a TCM-resident handler can
+       have one.  That makes these regions writable and executable, which for
+       tightly-coupled memory is the normal arrangement rather than an
+       oversight.  */
+
+    mpu_regions[6].mpu_region_base          = S32Z_ATCM_BASE;
+    mpu_regions[6].mpu_region_limit         = S32Z_ATCM_BASE + S32Z_ATCM_SIZE - 1UL;
+    mpu_regions[6].mpu_region_ap            = MPU_AP_RW_EL1;
+    mpu_regions[6].mpu_region_execute_never = 0U;
+    mpu_regions[6].mpu_region_shareability  = MPU_SH_NON;
+    mpu_regions[6].mpu_region_attr_index    = MPU_ATTR_NORMAL_WB;
+    mpu_regions[6].mpu_region_name          = "atcm  RW X  tcm";
+
+    /* No regions for BTCM and CTCM: entry.S leaves those banks disabled, and a
+       region covering a disabled TCM would map its address range to whatever
+       AXIM provides there, which is not TCM and would read as success.  See the
+       measurement in entry.S.  */
+
+    mpu_regions_used = 7U;
 }
 
 

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/platform.h
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/platform.h
@@ -74,6 +74,21 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
+/* TCM bases.  The values the S32Z2 reference manual documents, which the core
+   does not use until they are programmed -- ATCM boots at 0x00000000 and the
+   other two boot disabled with an UNKNOWN base.  Each must be size-aligned
+   (Cortex-R52 TRM r1p3 6.2), which these are: 64KB, 16KB and 16KB banks at
+   64KB, 1MB and 1MB alignment respectively.  Programming ATCM here also moves
+   it off address 0, so a null-pointer write faults instead of quietly landing
+   in tightly-coupled memory.  */
+
+#define S32Z_ATCM_BASE          0x30000000UL
+#define S32Z_ATCM_SIZE          0x00010000UL    /* 64 KB, 1 wait state  */
+#define S32Z_BTCM_BASE          0x30100000UL
+#define S32Z_BTCM_SIZE          0x00004000UL    /* 16 KB, 0 wait states */
+#define S32Z_CTCM_BASE          0x30200000UL
+#define S32Z_CTCM_SIZE          0x00004000UL    /* 16 KB, 1 wait state  */
+
 /* Memory-mapped register access.  Kept here rather than per-driver so that
    every peripheral in this BSP goes through one definition.
    MISRA C:2012 Rule 11.4/11.6 deviation: casting an integer address to a

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/readme_s32z280.txt
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/readme_s32z280.txt
@@ -87,8 +87,40 @@ model and not an R52 at all.
     ATCM needs 64-bit aligned stores where BTCM and CTCM accept 32-bit.  Using
     TCM therefore takes more than setting an enable bit.
 
-    The DDR window at 0x7A000000 is dark until DDR is initialised.  Both TCM
-    and DDR are absent from link.lds for now.
+    entry.S now programs ATCM to 0x30000000 and enables it at both exception
+    levels, at EL2 -- writing ENABLEEL2 from EL1 is silently ignored, measured on
+    two banks.  The boot image preloads it (ECC check bits are not initialised by
+    the core) and proves it holds data both before and after the MPU is enabled.
+
+    BTCM and CTCM are left disabled on purpose, and that is a measurement rather
+    than caution.  Enabling any second bank removes all measurable data-cache
+    benefit on this part:
+
+        ATCM only                      cache gain 24%
+        ATCM + BTCM                    cache gain  0%
+        ATCM + BTCM + CTCM             cache gain  0%
+        ATCM + BTCM at another base    cache gain  0%
+        ATCM + CTCM, BTCM disabled     cache gain  0%
+
+    Five configurations, one variable.  Not a particular bank, not its address,
+    not the ECC preload -- enabling a second bank at all.  The benchmark buffer is
+    in non-RTU-local SRAM at 0x31800000, outside every TCM window, and CCSIDR
+    reports the same 16 KB four-way cache throughout.
+
+    No erratum covers this.  Checked SDEN-857344 issue 19 (all 25 Cortex-R52
+    entries) and the S32Z2 0P91J mask set errata, whose RTU and R52 entries are
+    ERR050509, ERR051107, ERR051153, ERR051441, ERR051613, ERR051614 and
+    ERR052126.  A RAM pool shared between the RTU's last-level cache and the TCMs
+    would explain it -- the LLC "allocates ways to specific domains" -- but that is
+    a guess for NXP to confirm, and worth raising with the other RTU questions.
+
+    Losing nothing by this: the reference manual describes TCM_A as the bank
+    "optimized for small, regularly executed code such as interrupt service
+    routines or OS kernels", which is what a TCM is wanted for here.  Enabling the
+    other two is one line each in entry.S when there is an answer.
+
+    The DDR window at 0x7A000000 is dark until DDR is initialised.  TCM is still
+    absent from link.lds: nothing is placed there yet.
 
 
 5.  What this image reports

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/tcm.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/tcm.c
@@ -152,3 +152,111 @@ unsigned int tcm_ecc_enabled(void)
 
     return ((ctlr & MEMPROT_RAMPROTEN) != 0UL) ? 1U : 0U;
 }
+
+
+static void write_regionr(unsigned int index, unsigned long value)
+{
+    switch (index)
+    {
+        case 0U:
+            __asm volatile ("mcr p15, 0, %0, c9, c1, 0" :: "r" (value) : "memory");
+            break;
+        case 1U:
+            __asm volatile ("mcr p15, 0, %0, c9, c1, 1" :: "r" (value) : "memory");
+            break;
+        case 2U:
+            __asm volatile ("mcr p15, 0, %0, c9, c1, 2" :: "r" (value) : "memory");
+            break;
+        default:
+            return;
+    }
+
+    __asm volatile ("isb sy" ::: "memory");
+}
+
+
+unsigned int tcm_enable(unsigned int index, unsigned long base)
+{
+    tcm_bank_t  bank;
+    unsigned long value;
+
+    if (index > 2U)
+    {
+        return 0U;
+    }
+
+    tcm_read_bank(index, &bank);
+
+    if (bank.size_bytes == 0UL)
+    {
+        return 0U;                      /* not implemented; nothing to enable */
+    }
+
+    /* Size-aligned, per TRM 6.2.  Rejecting a misaligned base is better than
+       programming it and discovering later that the bank answers somewhere
+       unexpected.  */
+
+    if ((base & (bank.size_bytes - 1UL)) != 0UL)
+    {
+        return 0U;
+    }
+
+    /* Preserve the read-only SIZE and WAITSTATES fields as read: they describe
+       the hardware and writing a different value there would be meaningless.  */
+
+    value = (base & ~((1UL << TCM_BASE_SHIFT) - 1UL))
+          | (bank.raw & ((TCM_SIZE_MASK << TCM_SIZE_SHIFT) | (1UL << TCM_WAITSTATES_SHIFT)))
+          | TCM_ENABLE_EL2
+          | TCM_ENABLE_EL10;
+
+    write_regionr(index, value);
+
+    /* Read back rather than trusting the write.  */
+
+    tcm_read_bank(index, &bank);
+
+    /* ENABLEEL10 is the criterion, not both enables.  Writing ENABLEEL2 from
+       EL1 is ignored -- measured on BTCM and CTCM, where the base and bit 0 took
+       while bit 1 stayed clear -- so requiring it here would report failure for
+       a bank that is perfectly usable at the level this code runs at.  EL2
+       access is arranged in entry.S, before the drop.  */
+
+    return ((bank.base == (base & ~((1UL << TCM_BASE_SHIFT) - 1UL))) &&
+            (bank.enable_el10 != 0U)) ? 1U : 0U;
+}
+
+
+void tcm_preload(unsigned int index, unsigned long base, unsigned long bytes)
+{
+    if (index == 0U)
+    {
+        /* ATCM: 64-bit stores at 64-bit alignment.  TRM 6.2.2 is explicit that
+           STR of a word is not sufficient here, so this writes unsigned long
+           long and the generated code is checked to be STRD or STM rather than
+           two word stores.  */
+
+        volatile unsigned long long *p = (volatile unsigned long long *) base;
+        unsigned long count = bytes / 8UL;
+        unsigned long i;
+
+        for (i = 0UL; i < count; i++)
+        {
+            p[i] = 0ULL;
+        }
+    }
+    else
+    {
+        /* BTCM and CTCM: 32-bit stores at 32-bit alignment are enough.  */
+
+        volatile unsigned int *p = (volatile unsigned int *) base;
+        unsigned long count = bytes / 4UL;
+        unsigned long i;
+
+        for (i = 0UL; i < count; i++)
+        {
+            p[i] = 0U;
+        }
+    }
+
+    __asm volatile ("dsb sy" ::: "memory");
+}

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/tcm.h
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/tcm.h
@@ -114,4 +114,38 @@ unsigned long tcm_read_memprotctlr(void);
 unsigned int tcm_ecc_implemented(void);
 unsigned int tcm_ecc_enabled(void);
 
+/**************************************************************************/
+/*  ENABLING                                                              */
+/*                                                                        */
+/*    Constraints, all from Cortex-R52 TRM r1p3 section 6.2 and 3.3.94:    */
+/*                                                                        */
+/*    - The base address must be SIZE-ALIGNED, not merely 8KB-aligned as   */
+/*      the BASEADDRESS field's width alone would suggest.                */
+/*    - A disabled TCM's base address is UNKNOWN, not zero, so every bank  */
+/*      must be programmed explicitly rather than adjusted from what it    */
+/*      appears to hold.                                                  */
+/*    - "Before using the TCM you must program MPU regions to cover the    */
+/*      TCM regions to give access."  An enabled TCM with no MPU region    */
+/*      still faults once the MPU is on.                                  */
+/*    - An enabled TCM always behaves as Non-cacheable Non-shareable       */
+/*      Normal memory whatever the MPU says; the MPU supplies only the     */
+/*      permissions.  So the MPU region's attribute index is irrelevant    */
+/*      here and its AP and XN bits are not.                              */
+/*    - With ECC on, every location must be written before it is read.     */
+/*                                                                        */
+/**************************************************************************/
+
+/* Program one bank's base and enable it at both exception levels.  Returns 1 on
+   success, 0 if the index is out of range, the bank reports no size, or the base
+   is not size-aligned.  Verifies by reading the register back.  */
+
+unsigned int tcm_enable(unsigned int index, unsigned long base);
+
+/* Write every location of a bank so its ECC check bits become valid.  The store
+   width is chosen from the bank: index 0 is ATCM and needs 64-bit stores, and
+   the others take 32-bit.  Must be called while the bank is enabled and
+   accessible, and before anything reads it.  */
+
+void tcm_preload(unsigned int index, unsigned long base, unsigned long bytes);
+
 #endif


### PR DESCRIPTION
`entry.S` programs ATCM to `0x30000000` and enables it at both exception levels.

**This happens at EL2 deliberately.** Writing `ENABLEEL2` from EL1 is silently
ignored — measured on BTCM and CTCM, where the base took and `ENABLEEL10` took while
`ENABLEEL2` stayed clear, and the same write from EL2 sticks. `tcm_enable()` keeps
`ENABLEEL10` as its success criterion for the same reason: requiring both would
report failure for a bank that is perfectly usable at the level the caller runs at.

Programming ATCM also moves it off address 0, where `CFGTCMBOOTx` leaves it, so a
null-pointer write now faults instead of quietly landing in tightly-coupled memory.

The boot image verifies rather than programs, preloads ATCM (ECC is enabled and the
check bits are not initialised by the core), and proves the bank holds data both
before and after the MPU is enabled. One MPU region covers it — the TRM requires a
region before an enabled TCM can be used, and an enabled TCM always behaves as
Non-cacheable Non-shareable Normal memory whatever the region says, so only the
permissions there matter.

## BTCM and CTCM are off for a measured reason

Enabling **any** second bank removes all measurable data-cache benefit on this part:

| configuration | cache gain |
|---|---|
| ATCM only | **24%** |
| ATCM + BTCM | 0% |
| ATCM + BTCM + CTCM | 0% |
| ATCM + BTCM at another base | 0% |
| ATCM + CTCM, BTCM disabled | 0% |

Five configurations, one variable. Not a particular bank, not its address, and not
the ECC preload — enabling a second bank at all. The benchmark buffer is in
non-RTU-local SRAM at `0x31800000`, outside every TCM window, and CCSIDR reports the
same 16KB four-way cache throughout.

I was wrong twice while narrowing this, first blaming the preload and then blaming
BTCM specifically. Each was settled by a run rather than by argument, which is why
the table above is five rows.

**No erratum covers it.** Checked the Cortex-R52 errata notice SDEN-857344 issue 19
(all 25 entries) and the S32Z2 0P91J mask set errata, whose RTU and R52 entries are
`ERR050509`, `ERR051107`, `ERR051153`, `ERR051441`, `ERR051613`, `ERR051614`,
`ERR052126`. A RAM pool shared between the RTU's last-level cache and the TCMs would
explain it — the LLC is documented as allocating ways to specific domains — but that
is a guess, and it belongs with the other open questions for NXP.

Little is lost meanwhile: the reference manual describes TCM_A as the bank
*"optimized for small, regularly executed code such as interrupt service routines or
OS kernels"*, which is what a TCM is wanted for here. Enabling the other two is one
line each in `entry.S` once there is an answer.

## Two of my own checks were wrong

- **T5 reported every bank accessible while two were disabled.** A disabled TCM's
  address range is serviced through AXIM, so memory answering there says nothing
  about the TCM. It now requires the bank to be enabled as well. Worth flagging:
  that check would have shipped as evidence for something that wasn't happening.
- **T2 called `tcm_enable()` from EL1 for all three banks**, which would have
  switched on the very banks `entry.S` leaves off. It now verifies rather than
  programs.

## Verified on silicon

ATCM enabled and holding data before and after the MPU; cache benchmark back to
24%; protection checks X2 and X4 unchanged; ThreadX demo still 100 ticks with 20
preemptions.

Nothing is placed in TCM yet — `link.lds` is untouched. Putting a handler or a
thread stack there, and measuring it against SRAM, is the next step and a separate
change.
