### PR TITLE
Stopped the remaining example scripts naming archives that were deleted

### DIFF
--- a/ports/arm11/gnu/example_build/build_threadx_sample.bat
+++ b/ports/arm11/gnu/example_build/build_threadx_sample.bat
@@ -2,5 +2,5 @@ arm-none-eabi-gcc -c -g -mcpu=arm1136j-s reset.S
 arm-none-eabi-gcc -c -g -mcpu=arm1136j-s crt0.S
 arm-none-eabi-gcc -c -g -mcpu=arm1136j-s tx_initialize_low_level.S
 arm-none-eabi-gcc -c -g -mcpu=arm1136j-s -I../../../../common/inc -I../inc sample_threadx.c
-arm-none-eabi-ld -A arm1136j-s -T sample_threadx.ld reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a libc.a libnosys.a libgcc.a -o sample_threadx.out -M > sample_threadx.map
+arm-none-eabi-gcc -g -nostartfiles -mcpu=arm1136j-s -T sample_threadx.ld --specs=nosys.specs -o sample_threadx.out -Wl,-Map=sample_threadx.map reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/arm9/gnu/example_build/build_threadx_sample.bat
+++ b/ports/arm9/gnu/example_build/build_threadx_sample.bat
@@ -2,5 +2,5 @@ arm-none-eabi-gcc -c -g -mcpu=arm9 reset.S
 arm-none-eabi-gcc -c -g -mcpu=arm9 crt0.S
 arm-none-eabi-gcc -c -g -mcpu=arm9 tx_initialize_low_level.S
 arm-none-eabi-gcc -c -g -mcpu=arm9 -I../../../../common/inc -I../inc sample_threadx.c
-arm-none-eabi-ld -A arm9 -T sample_threadx.ld reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a libc.a libgcc.a -o sample_threadx.out -M > sample_threadx.map
+arm-none-eabi-gcc -g -nostartfiles -mcpu=arm9 -T sample_threadx.ld --specs=nosys.specs -o sample_threadx.out -Wl,-Map=sample_threadx.map reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/cortex_r4/gnu/example_build/build_threadx_sample.bat
+++ b/ports/cortex_r4/gnu/example_build/build_threadx_sample.bat
@@ -2,5 +2,5 @@ arm-none-eabi-gcc -c -g -mcpu=cortex-r4 reset.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-r4 crt0.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-r4 tx_initialize_low_level.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-r4 -I../../../../common/inc -I../inc sample_threadx.c
-arm-none-eabi-ld -A cortex-r4 -T sample_threadx.ld reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a libc.a libgcc.a -o sample_threadx.out -M > sample_threadx.map
+arm-none-eabi-gcc -g -nostartfiles -mcpu=cortex-r4 -T sample_threadx.ld --specs=nosys.specs -o sample_threadx.out -Wl,-Map=sample_threadx.map reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/cortex_r4/gnu/example_build/build_threadx_sample.sh
+++ b/ports/cortex_r4/gnu/example_build/build_threadx_sample.sh
@@ -61,5 +61,5 @@ esac
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-r4 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-r4 tx_initialize_low_level.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-r4 -I../../../../common/inc -I../inc sample_threadx.c
-arm-none-eabi-ld -A cortex-r4 -T sample_threadx.ld reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a libc.a libgcc.a -o sample_threadx.out -M > sample_threadx.map
+"${CC}" ${TARGET_FLAGS} -g -nostartfiles -mcpu=cortex-r4 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/cortex_r5/gnu/example_build/build_threadx_sample.bat
+++ b/ports/cortex_r5/gnu/example_build/build_threadx_sample.bat
@@ -2,5 +2,5 @@ arm-none-eabi-gcc -c -g -mcpu=cortex-r5 reset.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-r5 crt0.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-r5 tx_initialize_low_level.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-r5 -I../../../../common/inc -I../inc sample_threadx.c
-arm-none-eabi-ld -A cortex-r5 -T sample_threadx.ld reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a libc.a libgcc.a -o sample_threadx.out -M > sample_threadx.map
+arm-none-eabi-gcc -g -nostartfiles -mcpu=cortex-r5 -T sample_threadx.ld --specs=nosys.specs -o sample_threadx.out -Wl,-Map=sample_threadx.map reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/ports/cortex_r5/gnu/example_build/build_threadx_sample.sh
+++ b/ports/cortex_r5/gnu/example_build/build_threadx_sample.sh
@@ -61,5 +61,5 @@ esac
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-r5 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-r5 tx_initialize_low_level.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-r5 -I../../../../common/inc -I../inc sample_threadx.c
-arm-none-eabi-ld -A cortex-r5 -T sample_threadx.ld reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a libc.a libgcc.a -o sample_threadx.out -M > sample_threadx.map
+"${CC}" ${TARGET_FLAGS} -g -nostartfiles -mcpu=cortex-r5 -T sample_threadx.ld ${SYSCALL_LIB} -o sample_threadx.out -Wl,-Map=sample_threadx.map reset.o crt0.o tx_initialize_low_level.o sample_threadx.o tx.a
 

--- a/scripts/check_clang.sh
+++ b/scripts/check_clang.sh
@@ -188,13 +188,18 @@ CMAKE_EXAMPLE_CORES="cortex_r52"
 # their port directory, which covers both ports/ and ports_smp/. Listed
 # explicitly rather than silently skipped, so the gaps stay visible.
 #
-# These fail with the GNU toolchain too, so they are not LLVM problems:
-#   arm9 arm11           their linker scripts do not define _init and _fini.
-#                        Those symbols come from crti.o and crtn.o, which
-#                        -nostartfiles leaves out, so newlib's fini.c fails to
-#                        link. Reproduced with arm-none-eabi-gcc 13.2.1.
-#   cortex_r4 cortex_r5  need newlib multilib variants for those CPUs, which are
-#                        not present in every GNU toolchain packaging.
+# These fail with the GNU toolchain too, so they are not LLVM problems. All four
+# fail the same way, for the same reason:
+#
+#   their linker scripts define the .init and .fini sections but not the _init
+#   and _fini symbols. Those come from crti.o and crtn.o, which -nostartfiles
+#   leaves out, so newlib's fini.c cannot resolve them and the link ends with
+#   "undefined reference to `_fini'". Reproduced with arm-none-eabi-gcc 13.2.1.
+#
+# Until 6.1.10 the four linked libc.a and libgcc.a checked in beside them, which
+# supplied those symbols. That sweep removed the archives without updating the
+# link lines, so for years the examples failed earlier still, on the missing
+# files themselves. Fixing the link lines exposed the _fini gap underneath.
 EXAMPLES_EXPECTED_TO_FAIL="arm9 arm11 cortex_r4 cortex_r5"
 
 failures=0


### PR DESCRIPTION
## Problem

#618 fixed the `arm9` and `arm11` **shell** scripts but not their `.bat`
counterparts, and did not look at `cortex_r4` and `cortex_r5` at all. Auditing
every build script in the tree against the files actually present in its own
directory found the remainder.

Six scripts still linked archives removed in 6.1.10 under "Removal of unneeded
files":

| script | names |
|---|---|
| `ports/arm11/.../build_threadx_sample.bat` | `libc.a`, `libnosys.a`, `libgcc.a` |
| `ports/arm9/.../build_threadx_sample.bat` | `libc.a`, `libgcc.a` |
| `ports/cortex_r4/.../build_threadx_sample.bat` **and** `.sh` | `libc.a`, `libgcc.a` |
| `ports/cortex_r5/.../build_threadx_sample.bat` **and** `.sh` | `libc.a`, `libgcc.a` |

So on Windows all four examples failed exactly as the shell versions did before
#618, and on Linux the two R-profile ones still did:

```
arm-none-eabi-ld: cannot find libc.a: No such file or directory
```

## Change

Link through the compiler driver, the shape the other examples have used since
#594. The driver supplies libc and libgcc.

## What this does not fix, and the comment it corrects

It does not make the examples link. All four now fail identically:

```
undefined reference to `_fini'
```

Their linker scripts define the `.init` and `.fini` sections but not the `_init`
and `_fini` symbols, which live in `crti.o`/`crtn.o` and are omitted by
`-nostartfiles`. Until 6.1.10 the checked-in `libc.a`/`libgcc.a` supplied them.
That sweep removed the archives without touching the link lines, so the examples
failed earlier still — on the missing files — and fixing the link lines exposed
the gap underneath. Reviving four very old cores is separate work, so they stay
in `EXAMPLES_EXPECTED_TO_FAIL`.

The comment there is corrected again. It had `cortex_r4` and `cortex_r5` failing
for want of newlib multilib variants. They do not: they fail on `_fini`, exactly
like `arm9` and `arm11`. All four share one cause, and the multilib explanation
was wrong for the R-profile pair just as it was for the other two.

## Verification

- `cortex_r4` and `cortex_r5` were run before and after: `cannot find libc.a`
  becomes `undefined reference to '_fini'`, matching `arm9` and `arm11`.
- The `.bat` edits mirror link lines proven that way in the same directories.
  They cannot be executed here, which is stated rather than implied.
- `scripts/check_clang.sh` passes unchanged — 42 of 42 script-driven examples and
  5 of 5 Cortex-R52 CMake images. `scripts/check_ports.sh` passes.
- The `.bat` files are `eol=crlf` in `.gitattributes`; each shows a one-line diff,
  so no line-ending churn.

## Three scripts deliberately left alone

A blind edit could not be verified for these, so they are reported instead:

- `ports_module/cortex_m3` and `ports_module/cortex_m4` have Windows-only `.bat`
  scripts that name `libc.a`, but also name sources that are absent or differ in
  case — `build_threadx_sample.bat` compiles `sample_threadx.c`, which does not
  exist in that directory, and `cortexm_crt0.S` where the file is
  `cortexm_crt0.s`. Those scripts need more than an archive fix.
- `ports_smp/mips32_interaptiv_smp/.../build_threadx_demo.bat` names `libc.a` and
  needs a MIPS toolchain to test.

Two further matches were false positives and are untouched: the RISC-V scripts
mention `libthreadx.a` in comments, and the Green Hills harness passes `txe.a` to
`gbuild` as a target name rather than an input file.
