### PR TITLE
Corrected the S32Z280 data SRAM map against the Reference Manual and the part

### DIFF
--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
@@ -176,13 +176,13 @@ static void enable_irq_at_el1(void)
  *
  * Two things have to be right for a cache to show a measurable effect, and the
  * first version of this test got both wrong.  It used a 4 KB static buffer in
- * the RTU-local fast-data bank and reported a 0.036% difference -- noise -- as a
- * pass.  Fast local SRAM is already close to core speed, so caching it can save
- * almost nothing.
+ * DRAM0, a full-core-speed bank, and reported a 0.036% difference -- noise --
+ * as a pass.  A bank running at core speed leaves a cache almost nothing to
+ * save.  DRAM2 runs at half core speed, which is why the buffer lives there.
  *
  *   1. The memory must be slower than the core.  This uses the extended SRAM at
- *      S32Z_EXT_SRAM_BASE, which the Reference Manual describes as NOT
- *      RTU-local, unlike the fast-data bank.
+ *      S32Z_DRAM2_BASE, the RTU data bank that runs at half the core
+ *      frequency, so caching it has something to show.
  *
  *   2. The working set must fit in the cache and be revisited.  It is sized
  *      from CCSIDR at run time -- half the reported L1 data cache -- rather
@@ -197,7 +197,7 @@ static unsigned long cache_bench_words;
 
 static void cache_workload(void)
 {
-    volatile unsigned int  *buffer = (volatile unsigned int *) S32Z_EXT_SRAM_BASE;
+    volatile unsigned int  *buffer = (volatile unsigned int *) S32Z_DRAM2_BASE;
     unsigned long           pass;
     unsigned long           i;
 
@@ -656,7 +656,7 @@ void bsp_main(void)
     cache_bench_words = cache_dcache_bytes() / (2UL * sizeof(unsigned int));
     report("bench wds", (unsigned int) cache_bench_words);
 
-    linflexd_puts("C1 timing over non-RTU-local SRAM, caches OFF\n");
+    linflexd_puts("C1 timing over DRAM2, the half-speed bank, caches OFF\n");
     {
         unsigned long long before;
         unsigned long long after;
@@ -692,10 +692,9 @@ void bsp_main(void)
 
            A cache having little to offer here is plausible rather than
            broken.  Both the code and the data this workload touches live in
-           RTU-local low-latency SRAM, which is close to core speed already;
-           there is no slow memory on this board to demonstrate against.  DDR
-           would be the place to measure a real cache effect, and DDR is not
-           initialised.  */
+           full-speed RTU banks, which the core reaches at its own
+             clock; the only slower memory on this board is DRAM2 at
+             half speed, and DDR, which is not initialised.  */
 
         if (cache_enabled() == 1U)
         {

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/link.lds
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/link.lds
@@ -44,7 +44,7 @@ __sys_stack_size__ = 0x0800;
 MEMORY
 {
     CODE (rx)  : ORIGIN = 0x79900000, LENGTH = 0x00700000    /* 7 MB   */
-    DATA (rwx) : ORIGIN = 0x31780000, LENGTH = 0x00040000    /* 256 KB */
+    DATA (rwx) : ORIGIN = 0x31780000, LENGTH = 0x00080000    /* 512 KB: DRAM0 + DRAM1, both full core speed */
 }
 
 ENTRY(_start)

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/mpu.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/mpu.c
@@ -293,9 +293,13 @@ static void build_table(void)
     mpu_regions[0].mpu_region_name          = "code  RO X  normal-wb";
 
     /* Data, bss and every per-mode stack: writable, never executable.  Sized
-       from the SRAM bank, not from __data_end__: the stacks are NOLOAD and sit
+       from the SRAM banks, not from __data_end__: the stacks are NOLOAD and sit
        above that symbol, so sizing from it would leave them unmapped and the
-       first push after enabling the MPU would abort.  */
+       first push after enabling the MPU would abort.
+
+       This covers DRAM0 and DRAM1 together -- 512 KB, contiguous, both at full
+       core speed.  DRAM1 went undeclared until the banks were read out of the
+       Reference Manual and confirmed on the board.  */
 
     mpu_regions[1].mpu_region_base          = S32Z_DATA_SRAM_BASE;
     mpu_regions[1].mpu_region_limit         = S32Z_DATA_SRAM_BASE
@@ -338,19 +342,24 @@ static void build_table(void)
     mpu_regions[4].mpu_region_attr_index    = MPU_ATTR_DEVICE;
     mpu_regions[4].mpu_region_name          = "rtu   RW NX device";
 
-    /* Extended SRAM.  Deliberately mapped so the cache benchmark has memory
-       that is NOT RTU-local to work against: the fast-data bank in region 1 is
-       close to core speed, so caching it shows nothing.  Normal write-back and
-       never executable.  */
+    /* DRAM2.  Deliberately mapped so the cache benchmark has slower memory to
+       work against: this bank runs at half the core frequency, where region 1's
+       banks run at full speed and caching them shows little.  Normal write-back
+       and never executable.
 
-    mpu_regions[5].mpu_region_base          = S32Z_EXT_SRAM_BASE;
-    mpu_regions[5].mpu_region_limit         = S32Z_EXT_SRAM_BASE
-                                            + S32Z_EXT_SRAM_SIZE - 1UL;
+       Sized 512 KB, which is the whole bank.  An earlier revision mapped 2 MB
+       here; the upper 1.5 MB of that aliased back onto the bank, so anything
+       placed above 0x31880000 would have silently shared storage with the
+       bottom of the region -- no fault, just two objects on one address.  */
+
+    mpu_regions[5].mpu_region_base          = S32Z_DRAM2_BASE;
+    mpu_regions[5].mpu_region_limit         = S32Z_DRAM2_BASE
+                                            + S32Z_DRAM2_SIZE - 1UL;
     mpu_regions[5].mpu_region_ap            = MPU_AP_RW_EL1;
     mpu_regions[5].mpu_region_execute_never = 1U;
     mpu_regions[5].mpu_region_shareability  = MPU_SH_NON;
     mpu_regions[5].mpu_region_attr_index    = MPU_ATTR_NORMAL_WB;
-    mpu_regions[5].mpu_region_name          = "ext   RW NX normal-wb";
+    mpu_regions[5].mpu_region_name          = "dram2 RW NX normal-wb";
 
     /* One region per TCM bank.  The TRM is explicit that an enabled TCM still
        needs an MPU region before it can be used, and that an enabled TCM always

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/platform.h
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/platform.h
@@ -108,18 +108,36 @@
 
 #define S32Z_CODE_SRAM_DATA_ALIAS       0x32100000UL
 
-/* RTU-local data SRAM.  The Reference Manual notes that when an RTU      */
-/* accesses its own blocks the traffic stays inside the RTU, so this is   */
-/* the right home for stacks and .data.  256 KB.  [verified writable]     */
+/* RTU data SRAM.  The RTU has 1 MB of it, in three contiguous banks that */
+/* are all RTU-local -- when an RTU accesses its own blocks the traffic   */
+/* stays inside the RTU.  The banks differ in speed, not in locality:     */
+/*                                                                        */
+/*     DRAM0  0x31780000  256 KB  full core speed                         */
+/*     DRAM1  0x317C0000  256 KB  full core speed                         */
+/*     DRAM2  0x31800000  512 KB  half core speed                         */
+/*                                                                        */
+/* S32Z2 Reference Manual Rev. 5, section 6.3.6 and Table 13.  Confirmed  */
+/* on the board: writing distinct values to all three banks and reading   */
+/* them back shows 1 MB of independent storage, and the first address     */
+/* past DRAM2 aliases back onto its base, which is what fixes its size at */
+/* 512 KB rather than the 2 MB an earlier revision of this file claimed.  */
+/*                                                                        */
+/* Note that NXP's own debugger memory map, s32z2e2_memory_regions.py in  */
+/* S32 Design Studio, describes this last bank as 2 MB.  The Reference    */
+/* Manual and the silicon agree it is 512 KB; the script is wrong here.   */
 
-#define S32Z_DATA_SRAM_BASE             0x31780000UL
-#define S32Z_DATA_SRAM_SIZE             0x00040000UL
+#define S32Z_DRAM0_BASE                 0x31780000UL
+#define S32Z_DRAM0_SIZE                 0x00040000UL
+#define S32Z_DRAM1_BASE                 0x317C0000UL
+#define S32Z_DRAM1_SIZE                 0x00040000UL
+#define S32Z_DRAM2_BASE                 0x31800000UL
+#define S32Z_DRAM2_SIZE                 0x00080000UL
 
-/* Larger but not RTU-local: 2 MB, for images that outgrow the above.     */
-/* [verified writable]                                                    */
+/* The full-speed pair, contiguous, and the right home for stacks and     */
+/* .data.  This is what link.lds calls DATA.                              */
 
-#define S32Z_EXT_SRAM_BASE              0x31800000UL
-#define S32Z_EXT_SRAM_SIZE              0x00200000UL
+#define S32Z_DATA_SRAM_BASE             S32Z_DRAM0_BASE
+#define S32Z_DATA_SRAM_SIZE             (S32Z_DRAM0_SIZE + S32Z_DRAM1_SIZE)
 
 /* Console.  The EVB user guide (UG10268) dedicates LIN9 to the           */
 /* daughtercard USB-UART, selected by jumper J248, so LINFlex_9 is the    */


### PR DESCRIPTION
The RTU has 1 MB of data SRAM in three contiguous banks, and this port described it wrongly in both directions.

| bank | address | size | speed |
|---|---|---|---|
| DRAM0 | `0x31780000` | 256 KB | full core speed |
| DRAM1 | `0x317C0000` | 256 KB | full core speed |
| DRAM2 | `0x31800000` | 512 KB | half core speed |

**DRAM1 was not declared at all**, so 256 KB of full-speed memory went unused and the linker's `DATA` region stopped at 256 KB.

**DRAM2 was declared as 2 MB when it is 512 KB**, which mattered more: the MPU mapped 1.5 MB past the end of the bank, and that range aliases back onto its base. Anything placed above `0x31880000` would have shared storage with the bottom of the region silently — no fault, two objects at one address. Nothing was placed there yet, so this was a trap rather than a live defect.

## How the sizes were established

S32Z2 Reference Manual Rev. 5, section 6.3.6 and Table 13, and the board itself. Writing distinct values to all three banks and reading them all back afterwards — rather than one at a time, which cannot tell memory from an alias — shows 1 MB of independent storage. The first word past DRAM2 returns the value written to its base, which is what fixes the size at 512 KB.

Worth recording: NXP's own debugger memory map, `s32z2e2_memory_regions.py` in S32 Design Studio, calls the last bank 2 MB ("2 M on S250, but 4 MB elsewhere"). The Reference Manual and the silicon agree it is 512 KB.

## Description of the banks

They are all RTU-local. The earlier comments treated locality as the thing that distinguishes them, when the actual difference is clock speed. That is why the cache benchmark uses DRAM2 — caching a bank that already runs at core speed shows nothing, which is a real effect the old wording explained with the wrong cause.

## Verification

Builds clean with no warnings. On the S32Z280-594EVB the boot probes pass six of six, exercising the MPU, GIC, interrupts, caches, and both protection faults:

```
M2 MPU enabled, console alive          M4 GIC reachable
C1 timing over DRAM2, the half-speed bank, caches OFF
C3 PASS caches enabled                 C4 PASS caches measurably faster (>=10%)
X2 PASS write to code faulted and was recovered
X4 PASS execute from data faulted and was recovered
```