### PR TITLE
Added a CMake target for the Linux sample program

### DIFF
--- a/ports/linux/gnu/CMakeLists.txt
+++ b/ports/linux/gnu/CMakeLists.txt
@@ -20,3 +20,10 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC "-D_GNU_SOURCE -DTX_LINUX_DEBUG_ENABLE")
+
+# The demo program beside the port. Off by default so the ordinary build
+# produces just the library; -DTHREADX_SAMPLE=ON adds the sample_threadx target.
+option(THREADX_SAMPLE "Build the sample program for this port" OFF)
+if(THREADX_SAMPLE)
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/example_build)
+endif()

--- a/ports/linux/gnu/example_build/CMakeLists.txt
+++ b/ports/linux/gnu/example_build/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Build the sample_threadx program that ports/linux/gnu/Makefile builds, so the
+# CMake build can produce a runnable demo rather than only the library.
+#
+# Guarded by THREADX_SAMPLE in the parent so the default build stays a pure
+# library build.
+
+add_executable(sample_threadx)
+
+target_sources(sample_threadx PRIVATE ${CMAKE_CURRENT_LIST_DIR}/sample_threadx.c)
+
+target_include_directories(sample_threadx
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../inc
+    ${CMAKE_CURRENT_LIST_DIR}/../../../../${TX_COMMON_DIR}/inc
+)
+
+target_link_libraries(sample_threadx PRIVATE threadx)

--- a/ports_smp/linux/gnu/CMakeLists.txt
+++ b/ports_smp/linux/gnu/CMakeLists.txt
@@ -31,3 +31,10 @@ target_include_directories(${PROJECT_NAME}
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )
+
+# The demo program beside the port. Off by default so the ordinary build
+# produces just the library; -DTHREADX_SAMPLE=ON adds the sample_threadx target.
+option(THREADX_SAMPLE "Build the sample program for this port" OFF)
+if(THREADX_SAMPLE)
+    add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/example_build)
+endif()

--- a/ports_smp/linux/gnu/example_build/CMakeLists.txt
+++ b/ports_smp/linux/gnu/example_build/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Build the sample_threadx program that ports/linux/gnu/Makefile builds, so the
+# CMake build can produce a runnable demo rather than only the library.
+#
+# Guarded by THREADX_SAMPLE in the parent so the default build stays a pure
+# library build.
+
+add_executable(sample_threadx)
+
+target_sources(sample_threadx PRIVATE ${CMAKE_CURRENT_LIST_DIR}/sample_threadx.c)
+
+target_include_directories(sample_threadx
+    PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../inc
+    ${CMAKE_CURRENT_LIST_DIR}/../../../../${TX_COMMON_DIR}/inc
+)
+
+target_link_libraries(sample_threadx PRIVATE threadx)


### PR DESCRIPTION
## Problem

The CMake build produces `libthreadx.a` and nothing else. Anyone wanting to try
ThreadX on Linux has to use the Makefile beside the port instead, even though the
demo source is sitting right there in `example_build/`.

## Change

Build that demo, for the `linux` port and its SMP counterpart, behind an option
that defaults off so an ordinary build is unchanged:

```sh
cmake -S . -B build -DTHREADX_ARCH=linux -DTHREADX_TOOLCHAIN=gnu -DTHREADX_SAMPLE=ON
cmake --build build --target sample_threadx
```

The include path uses `${TX_COMMON_DIR}` rather than naming `common` or
`common_smp` directly, since the top level already resolves which of the two
applies.

## Verification

Both variants build **and run**:

```
**** ThreadX Linux Demonstration **** (c) 1996-2020 Microsoft Corporation

           thread 0 events sent:          1
           thread 1 messages sent:        0
```

and the SMP configuration prints `**** ThreadX SMP Linux Demonstration ****`,
both with the demo's counters advancing.

A default configure — no `THREADX_SAMPLE` — has no `sample_threadx` target and
still produces `libthreadx.a`, so nothing existing changes.
`scripts/check_ports.sh` passes.

## Credit

Derived from the two `example_build/CMakeLists.txt` files in #404 by
@yf13, which had exactly this goal.

That change also rewrote the top level's SMP selection, added
`common_smp/CMakeLists.txt`, and added `ports_smp/linux/gnu/CMakeLists.txt`. All
three have since arrived on `dev` by other routes, so the sample targets were the
only part still missing. The include path needed one adjustment: the original
read `common${THREADX_SMP}/inc`, which depended on `THREADX_SMP` being a string
suffix. It is a boolean on `dev` today, so that expression would expand to
`commonON`.
