### PR TITLE
Stopped the generated Armv8-M readmes claiming a false origin date

### DIFF
--- a/ports/cortex_m33/ac6/readme_threadx.txt
+++ b/ports/cortex_m33/ac6/readme_threadx.txt
@@ -218,7 +218,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M33 using AC6 tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using AC6 tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m33/gnu/readme_threadx.txt
+++ b/ports/cortex_m33/gnu/readme_threadx.txt
@@ -200,7 +200,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M33 using GNU tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using GNU tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m33/iar/readme_threadx.txt
+++ b/ports/cortex_m33/iar/readme_threadx.txt
@@ -211,7 +211,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M33 using IAR's ARM tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using IAR's ARM tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m52/ac6/readme_threadx.txt
+++ b/ports/cortex_m52/ac6/readme_threadx.txt
@@ -218,7 +218,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M52 using AC6 tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using AC6 tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m52/gnu/readme_threadx.txt
+++ b/ports/cortex_m52/gnu/readme_threadx.txt
@@ -200,7 +200,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M52 using GNU tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using GNU tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m52/iar/readme_threadx.txt
+++ b/ports/cortex_m52/iar/readme_threadx.txt
@@ -211,7 +211,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M52 using IAR's ARM tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using IAR's ARM tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m55/ac6/readme_threadx.txt
+++ b/ports/cortex_m55/ac6/readme_threadx.txt
@@ -218,7 +218,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M55 using AC6 tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using AC6 tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m55/gnu/readme_threadx.txt
+++ b/ports/cortex_m55/gnu/readme_threadx.txt
@@ -200,7 +200,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M55 using GNU tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using GNU tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m55/iar/readme_threadx.txt
+++ b/ports/cortex_m55/iar/readme_threadx.txt
@@ -211,7 +211,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M55 using IAR's ARM tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using IAR's ARM tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m85/ac6/readme_threadx.txt
+++ b/ports/cortex_m85/ac6/readme_threadx.txt
@@ -218,7 +218,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M85 using AC6 tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using AC6 tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m85/gnu/readme_threadx.txt
+++ b/ports/cortex_m85/gnu/readme_threadx.txt
@@ -200,7 +200,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M85 using GNU tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using GNU tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports/cortex_m85/iar/readme_threadx.txt
+++ b/ports/cortex_m85/iar/readme_threadx.txt
@@ -211,7 +211,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-M85 using IAR's ARM tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using IAR's ARM tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports_arch/ARMv8-M/threadx/ac6/readme_threadx.txt
+++ b/ports_arch/ARMv8-M/threadx/ac6/readme_threadx.txt
@@ -218,7 +218,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-Mxx using AC6 tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using AC6 tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports_arch/ARMv8-M/threadx/gnu/readme_threadx.txt
+++ b/ports_arch/ARMv8-M/threadx/gnu/readme_threadx.txt
@@ -200,7 +200,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-Mxx using GNU tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using GNU tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation

--- a/ports_arch/ARMv8-M/threadx/iar/readme_threadx.txt
+++ b/ports_arch/ARMv8-M/threadx/iar/readme_threadx.txt
@@ -211,7 +211,12 @@ information associated with this specific port of ThreadX:
 03-02-2021  The following files were changed/added for version 6.1.5:
             tx_port.h                       Added ULONG64_DEFINED
 
-09-30-2020  Initial ThreadX 6.1 version for Cortex-Mxx using IAR's ARM tools.
+09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using IAR's ARM tools.
+
+            The dates above belong to this shared port, which every Armv8-M
+            core is generated from. They are not the date a particular core
+            gained a ThreadX port: that is when its name was added to
+            scripts/copy_armv8_m.sh.
 
 
 Copyright(c) 1996-2020 Microsoft Corporation


### PR DESCRIPTION
## Problem

Every generated Armv8-M port readme ends with a line like

```
09-30-2020  Initial ThreadX 6.1 version for Cortex-M85 using GNU tools.
```

The core name is substituted in by `scripts/copy_armv8_m.sh`, but the date is the
shared port's, so each core inherits it regardless of its own history. Cortex-M85
was announced in 2022 and its readme claims a 2020 origin. Any core added later
gets the same fabricated line the moment its name joins the generator's list —
which is how it came to light, while reviewing #519.

The rest of the history block is fine: those entries record changes to the shared
Armv8-M files, which is exactly what they should do. Only the closing line asserts
something per-core that the generator cannot know.

## Change

Reword that line in the three `ports_arch/ARMv8-M/threadx/*/readme_threadx.txt`
templates to describe the shared port, and say where a core's real starting point
is:

```
09-30-2020  Initial ThreadX 6.1 version of this Armv8-M port using GNU tools.

            The dates above belong to this shared port, which every Armv8-M
            core is generated from. They are not the date a particular core
            gained a ThreadX port: that is when its name was added to
            scripts/copy_armv8_m.sh.
```

Regenerating propagates it to the twelve readmes for `cortex_m33`, `cortex_m52`,
`cortex_m55` and `cortex_m85` across the three toolchains.

Cortex-M52 makes the case concrete: it arrived in #519 and its readme immediately
claimed a 2020 origin for a core announced in 2023.

## Scope

Only the generated Armv8-M readmes are touched. Some hand-maintained readmes carry
the same sentence — `cortex_m0`, `cortex_m23`, and the Keil variants of `cortex_m3`
and `cortex_m4` — but those cores all predate the date, so "the first ThreadX 6.1
release supporting this core was 2020-09-30" is a plausible claim rather than a
fabricated one. The generator's failure is specific: substitution mints a per-core
origin for cores that did not exist when the template was written.

The ARMv7-M templates end with `Initial ThreadX version 6.1.7 for Cortex-M using
GNU tools` — no placeholder, so nothing is substituted and no per-core claim is
made. Verified against the generated `cortex_m3`, `cortex_m4` and `cortex_m7`
readmes, which all carry that same generic wording. They are left alone.

## Verification

`scripts/check_ports.sh` passes, so the templates and their generated copies
agree and regeneration is a no-op. No placeholder leaks into the generated text.

## Ordering with #519

Handled: #519 merged first, this branch has been rebased onto it and regenerated,
so Cortex-M52's three readmes are included and `check_ports.sh` reports no drift.
