### PR TITLE
Stopped POSIX mq_send() leaking the message buffer when the send fails

### DIFF
--- a/utility/rtos_compatibility_layers/posix/px_mq_send.c
+++ b/utility/rtos_compatibility_layers/posix/px_mq_send.c
@@ -60,6 +60,7 @@
 /*                                                                        */
 /*    tx_thread_identify                returns currently running thread  */
 /*    tx_byte_allocate                  allocate memory                   */
+/*    tx_byte_release                   release memory                    */
 /*    tx_queue_send                     ThreadX queue send                */
 /*    posix_priority_search             search message for same priority  */
 /*                                                                        */
@@ -201,9 +202,14 @@ ULONG               msg[TX_POSIX_MESSAGE_SIZE];
     temp1 = tx_queue_send(Queue, msg, TX_WAIT_FOREVER);
     if ( temp1 != TX_SUCCESS)
     {
+        /* The message was never handed over to the queue, so this function
+           still owns the private buffer. Release it before returning,
+           otherwise it is leaked from the queue's byte pool.  */
+        tx_byte_release(bp);
+
         /* POSIX doesn't have error for this, hence give default.  */
         posix_errno = EINTR ;
-	    posix_set_pthread_errno(EINTR);
+        posix_set_pthread_errno(EINTR);
 
         /* Return ERROR.  */
         return(ERROR);


### PR DESCRIPTION
Fixes #568, reported by @K-ANOY, who also proposed this fix.

`mq_send()` allocates a private buffer from the queue's own byte pool, copies the caller's message into it, and passes the buffer's address through the queue. Ownership transfers to the receiver: `px_mq_receive.c:225` releases the buffer once it has copied the message out.

If `tx_queue_send()` fails the message never reaches the queue, so no receiver will ever release that buffer, and `mq_send()` returned `ERROR` while holding the only pointer to it.

## Reachability

With `TX_WAIT_FOREVER` the send suspends, and `tx_queue_send()` returns the thread's suspend status. Two routes reach the branch, and only one of them matters:

- **Wait abort.** `tx_thread_wait_abort()` sets `TX_WAIT_ABORTED` on the suspended sender (`tx_thread_wait_abort.c:113`). The queue survives, so the pool shrinks with every aborted send. This is the leak worth fixing.
- **Queue deletion.** `tx_queue_delete.c:154` sets `TX_DELETED`. But `vq_message_area` is a `TX_BYTE_POOL` embedded in the queue structure (`tx_posix.h:395`), created in `px_mq_create.c:195` and destroyed in `px_mq_reset_queue.c:77` — the pool dies with the queue, so nothing outlives the failure here.

## Impact

Worse than a lost allocation. Once the pool is exhausted, `tx_byte_allocate()` fails and control reaches `posix_internal_error(9999)`, which is

```c
VOID posix_internal_error(ULONG error_code)
{
    while (error_code) { ; }
}
```

A non-zero code never returns, so the calling thread spins forever instead of getting an error back. The symptom is a thread that stops making progress, not an `mq_send()` that reports failure.

## Scope

`mq_send()` is the only instance. Three files in the layer call `tx_byte_allocate()`: this one, `px_mq_get_queue_desc.c` (returns before it has anything to leak), and `px_memory_allocate.c` (hands the allocation to the caller).

## Verification

The POSIX layer is not wired into any build system in the repository, and it cannot be built against the `linux` port — its `pthread.h` uses the guard `_PTHREAD_H`, which glibc's header has already defined by the time `tx_api.h` pulls it in, so the layer's own declarations get silently skipped. I compiled it for `cortex_m4` with the project's reference toolchain (`arm-gnu-toolchain-14.3.rel1`) at `-O2` and compared the generated code against `dev`:

```
BEFORE: _tx_thread_identify _txe_byte_allocate _txe_queue_send  ...
AFTER:  _tx_thread_identify _txe_byte_allocate _txe_byte_release _txe_queue_send ...
```

and checked that the released pointer is the allocated one rather than something else on the stack:

```
  46:  add   r1, sp, #4        <- &bp handed to _txe_byte_allocate
  4c:  bl    _txe_byte_allocate
  82:  bl    _txe_queue_send
  c0:  ldr   r0, [sp, #4]      <- the same slot
  c2:  bl    _txe_byte_release
  cc:  bl    posix_set_pthread_errno   <- EINTR path
```

`EINTR` reporting is unchanged; mapping `TX_WAIT_ABORTED` onto it is reasonable.

## Note for a later change

The missing `return` after `posix_internal_error()` is load bearing today: the code only stays correct because that helper never comes back. If it were ever made to return, control would fall through and copy `msg_len` bytes through an unset `bp`. Not a defect now, and out of scope here, but worth knowing before anyone tidies that function.
