### PR TITLE
Stopped two POSIX call sites falling through their error handler

### DIFF
--- a/utility/rtos_compatibility_layers/posix/px_mq_send.c
+++ b/utility/rtos_compatibility_layers/posix/px_mq_send.c
@@ -167,7 +167,16 @@ ULONG               msg[TX_POSIX_MESSAGE_SIZE];
 
     if (temp1 != TX_SUCCESS)
     {
-    posix_internal_error(9999);
+        posix_internal_error(9999);
+
+        /* posix_internal_error() does not return today, but do not depend on
+           that: bp is indeterminate here, so falling through would copy
+           msg_len bytes through an unset pointer.  */
+        posix_errno = ENOMEM;
+        posix_set_pthread_errno(ENOMEM);
+
+        /* Return ERROR.  */
+        return(ERROR);
     }
     /* Got the memory , Setup source and destination pointers
        Cast them in UCHAR as message length is in bytes.  */

--- a/utility/rtos_compatibility_layers/posix/px_pth_init.c
+++ b/utility/rtos_compatibility_layers/posix/px_pth_init.c
@@ -538,7 +538,13 @@ POSIX_TCB          *p_tcb;
     if (!thread_ptr)
     {
         /* Not called from a thread - error!  */
-           posix_internal_error(222);
+        posix_internal_error(222);
+
+        /* posix_internal_error() does not return today, but do not depend on
+           that: posix_thread2tcb() hands back NULL for this input and the read
+           below would dereference it. A pthread ID is the address of the TCB,
+           so zero is never a valid one.  */
+        return((pthread_t) 0);
     }
 
     /* Get the TCB for this pthread */


### PR DESCRIPTION
Follow-up to #624, which noted this in passing.

`posix_internal_error()` never returns for a non-zero code — its body is `while (error_code) { ; }`. Most callers in the layer still follow it with an explicit error return. Two do not, and both fall through into a pointer dereference, so they are correct only because the handler happens to hang.

## Is the hazard live?

No, and I checked rather than assuming. The C standard lets an implementation assume a loop with no side effects terminates (C11 6.8.5p6), which would make the fall-through reachable, so the guarantee is a property of the toolchain and not of the language. Both toolchains the project supports keep the loop:

| toolchain | -O0 | -O1 | -O2 | -Os |
|---|---|---|---|---|
| GCC 14.3 (arm-none-eabi) | loops | loops | loops | loops |
| Clang 22 (ATfE) | loops | — | loops | — |

So nothing is broken today. Neither call site should depend on it.

## The two sites

**`mq_send()`** falls through with `bp` indeterminate, immediately after being told the allocation failed, and would copy `msg_len` bytes through it. Now reports `ENOMEM` and returns `ERROR`.

**`posix_thread2tid()`** falls through with `thread_ptr` NULL. `posix_thread2tcb()` returns NULL for that input and the next line reads `p_tcb->pthreadID`. Now returns zero, which is never a valid pthread ID because `px_pth_create.c:248` assigns the address of the TCB as the ID.

The other fall-through sites are fine: they continue into recovery that does not dereference anything, or sit at the end of a void function. `posix_thread2tcb()`'s own `!thread_ptr` branch is safe too, because `is_posix_thread()` only compares pointers against the TCB pool bounds and never dereferences.

## Effect

None while the handler keeps hanging. Both additions are unreachable today; they exist so that changing the handler cannot turn into memory corruption.

Verified by compiling both files for `cortex_m4` with the project's reference toolchain at `-O2 -Wall -Wextra`, clean, and by checking the generated code takes the new path: after `bl posix_internal_error` the code stores 4444 (`ENOMEM`) into `posix_errno`, calls `posix_set_pthread_errno`, and branches to the shared `ERROR` epilogue instead of continuing into the copy loop.

## Separately

While confirming the `posix_thread2tid()` path I found a live NULL dereference that is not about the error handler at all, so it is not in this PR: `pthread_self()` called from a plain ThreadX thread reaches `posix_thread2tcb()`, gets NULL because the thread is not in the TCB pool, and dereferences it. `px_pth_self.c` then reads `((POSIX_TCB *) thread_ptr) -> signals.signal_handler` on a thread that is not a `POSIX_TCB` at all. I will raise that on its own, since deciding what `pthread_self()` should return for a non-POSIX thread is a semantic question rather than a hardening one.
