### PR TITLE
Configured the LINFlexD console twice, because once is not enough at -O2

### DIFF
--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/linflexd.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/linflexd.c
@@ -104,7 +104,10 @@
 #define CONSOLE_BASE            S32Z_LINFLEX_9_BASE
 
 
-unsigned int linflexd_init(void)
+/* One full pass of the configuration sequence.  Called twice by
+   linflexd_init; see the comment there for why.  */
+
+static unsigned int linflexd_configure_once(void)
 {
     unsigned int  status = LINFLEXD_INIT_OK;
     unsigned int  guard;
@@ -162,6 +165,37 @@ unsigned int linflexd_init(void)
     /* Leave initialisation mode; the module starts operating.  */
 
     REG32(CONSOLE_BASE + LINFLEXD_LINCR1) = 0U;
+
+    return status;
+}
+
+
+unsigned int linflexd_init(void)
+{
+    unsigned int status;
+
+    /* The sequence runs twice, and one pass is genuinely not enough.
+       A single pass gives a working console when this file is compiled at -O0
+       and a corrupted one at -O2: every character partially wrong, while UARTCR
+       reads back exactly the value written, LINIBRR and LINFBRR read back
+       exactly the values written, and the returned status is
+       LINFLEXD_INIT_OK.  The registers are right and the line is wrong, so the
+       failure is invisible to the caller -- the worst property a console can
+       have, and the reason this is worth two passes at boot.
+
+       The mechanism is not understood.  Tested and rejected as explanations:
+       the wait for initialisation mode (a bound 100x larger changes nothing),
+       a settling delay before the first LINSR read, a settling delay after
+       leaving initialisation mode, a barrier and read-back between the two
+       UARTCR writes, and waiting for LINSR to report the exit from
+       initialisation mode.  None of those makes a single pass work at -O2.
+       A second pass does, reliably, at both optimisation levels.
+
+       Verified on the S32Z280-594EVB with the whole BSP at -O0 and at -O2.
+       If the underlying behaviour is ever identified, revisit this.  */
+
+    status  = linflexd_configure_once();
+    status |= linflexd_configure_once();
 
     return status;
 }


### PR DESCRIPTION
The S32Z280 console driver runs its configuration sequence once, and that works only because this BSP is built without an optimisation flag (`CMAKE_BUILD_TYPE` is empty, so everything compiles at `-O0`). Compiled at `-O2` the same sequence leaves the line corrupted — every character partially wrong, in exactly the pattern the file already documents for a module configured outside initialisation mode.

## Why this is worth guarding against

The failure is **invisible to the caller**:

- `UARTCR` reads back exactly the value written (`0x33`)
- `LINIBRR` reads back 21, the value written
- `LINFBRR` reads back 11, the value written
- `linflexd_init` returns `LINFLEXD_INIT_OK`

The registers are right and the line is wrong. Nothing in the returned status says the console cannot be trusted, which is the worst property a console can have — it is the instrument every other bring-up result is read through.

## How it was localised

By bisection rather than inspection:

| build | result |
|---|---|
| everything `-O2`, `linflexd.c` at `-O0` | clean |
| everything `-O0`, only `linflexd_init` at `-O2` | corrupted |
| everything `-O0`, only `linflexd_putc` at `-O2` | clean |

So the fault is in the configuration sequence, not the per-byte transmit path. The `putc` DTF handshake — whose comment warns that its ordering is load-bearing in both directions — is innocent and untouched.

The register read-backs above were obtained by instrumenting a duplicate of the sequence forced to `-O2` and reporting its observations through a console repaired afterwards by a known-good pass.

## What this commit does not claim

The mechanism is not understood. Tested and rejected as explanations:

- a 100× larger bound on the wait for initialisation mode
- a settling delay before the first `LINSR` read
- a settling delay after leaving initialisation mode
- a barrier and read-back between the two `UARTCR` writes
- waiting for `LINSR` to report the exit from initialisation mode

None makes a single pass work at `-O2`. A second pass does, reliably, at both optimisation levels. Since delays do not help but a second pass does, the evidence points away from timing, and the comment in the code says so and lists what was ruled out, so the next person does not repeat it.

## Verification

On the S32Z280-594EVB:

- boot image passes six of six probes, console status still `0x00000000`
- the standalone reproducer prints correctly at both `-O0` and `-O2`, where previously `-O2` was unreadable
- builds clean with no warnings