### PR TITLE
Revalidated the ATCM handler result across four placements, and it holds

### DIFF
--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
@@ -750,19 +750,58 @@ void bsp_main(void)
                 sum += (unsigned long) v;
             }
 
-            linflexd_puts("I5 handler body cycles ");
+            linflexd_puts("I5 handler body cycles, four placements ");
 #ifdef TX_R52_ATCM_ISR
-            linflexd_puts("(body in ATCM)\n");
+            linflexd_puts("(bodies in ATCM)\n");
 #else
-            linflexd_puts("(body in code RAM)\n");
+            linflexd_puts("(bodies in code RAM)\n");
 #endif
             report("samples  ", n);
-            if (n > 0U)
+
+            /* Per placement, because the aggregate hides exactly the thing that
+               invalidated the previous version of this comparison.  16 samples
+               each, in the order the wrapper rotated through them.  */
+
             {
-                report("min      ", lo);
-                report("max      ", hi);
-                report("mean     ", (unsigned int) (sum / n));
-                report("spread   ", hi - lo);
+                unsigned int slot;
+                unsigned int each = 64U / 4U;
+
+                for (slot = 0U; slot < 4U; slot++)
+                {
+                    unsigned int s_lo = 0xFFFFFFFFU;
+                    unsigned int s_hi = 0U;
+                    unsigned long s_sum = 0UL;
+                    unsigned int c = 0U;
+                    unsigned int m;
+
+                    for (m = slot * each; (m < ((slot + 1U) * each)) && (m < n); m++)
+                    {
+                        unsigned int v = board_service_cycles[m];
+
+                        if (v < s_lo) { s_lo = v; }
+                        if (v > s_hi) { s_hi = v; }
+                        s_sum += (unsigned long) v;
+                        c++;
+                    }
+
+                    linflexd_puts("  offset ");
+                    report_dec((unsigned long) (slot * 16U));
+                    linflexd_puts(": ");
+                    if (c == 0U)
+                    {
+                        linflexd_puts("no samples\n");
+                    }
+                    else
+                    {
+                        linflexd_puts("min ");
+                        report_dec((unsigned long) s_lo);
+                        linflexd_puts("  max ");
+                        report_dec((unsigned long) s_hi);
+                        linflexd_puts("  mean ");
+                        report_dec(s_sum / c);
+                        linflexd_puts("\n");
+                    }
+                }
             }
         }
         report("first INTID", (unsigned int) board_first_intid);

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/irq_dispatch.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/irq_dispatch.c
@@ -193,32 +193,28 @@ unsigned int board_service_count;
 #define BOARD_ISR_SECTION
 #endif
 
-__attribute__((aligned(64)))
-static BOARD_ISR_SECTION void board_irq_service_body(unsigned long intid);
+static inline __attribute__((always_inline))
+void board_irq_service_impl(unsigned long intid);
 
-void board_irq_service(unsigned long intid)
-{
-    unsigned int before;
-    unsigned int after;
 
-    before = timer_read_cycles();
-    board_irq_service_body(intid);
-    after  = timer_read_cycles();
-
-    if (board_service_count < BOARD_LATENCY_SAMPLES)
-    {
-        board_service_cycles[board_service_count] = after - before;
-        board_service_count++;
-    }
-}
 
 
 /* Aligned for the same reason as cache_workload: this body is timed, and
    without a fixed alignment the figure moves with unrelated code changes
    elsewhere in the image.  */
 
-__attribute__((aligned(64)))
-static BOARD_ISR_SECTION void board_irq_service_body(unsigned long intid)
+/* Four placements of one implementation.  The logic below is inlined into each
+   of the four wrappers further down, each 64-byte aligned and then displaced by
+   a different offset within the line, and the measurement rotates through them.
+
+   A single placement is not measurable.  The cache benchmark in this file's
+   sibling turned out to be bimodal with respect to exactly this, reporting 24%
+   or 0% for identical silicon depending on where a loop fell in a line, and it
+   invalidated a handler comparison and a defect report to NXP before anyone
+   noticed.  Pinning one alignment does not fix that, it just chooses a mode.  */
+
+static inline __attribute__((always_inline))
+void board_irq_service_impl(unsigned long intid)
 {
     if (intid == GICV3_SPURIOUS_INTID)
     {
@@ -300,6 +296,62 @@ static BOARD_ISR_SECTION void board_irq_service_body(unsigned long intid)
     }
 
     board_nest_depth--;
+}
+
+
+/* The four placements.  pad nops shift the inlined body within its line.  */
+
+#define MAKE_ISR_BODY(name, pad)                                              \
+__attribute__((aligned(64), noinline))                                        \
+static BOARD_ISR_SECTION void name(unsigned long intid)                       \
+{                                                                             \
+    __asm__ volatile(".rept " #pad "\n\tnop\n\t.endr");                       \
+    board_irq_service_impl(intid);                                            \
+}
+
+MAKE_ISR_BODY(board_irq_body_a, 0)
+MAKE_ISR_BODY(board_irq_body_b, 4)
+MAKE_ISR_BODY(board_irq_body_c, 8)
+MAKE_ISR_BODY(board_irq_body_d, 12)
+
+#define BOARD_ISR_PLACEMENTS    4U
+#define BOARD_SAMPLES_EACH      (BOARD_LATENCY_SAMPLES / BOARD_ISR_PLACEMENTS)
+
+static void (*const board_irq_bodies[BOARD_ISR_PLACEMENTS])(unsigned long) =
+{
+    board_irq_body_a,       /* body at line offset 0  */
+    board_irq_body_b,       /* body at line offset 16 */
+    board_irq_body_c,       /* body at line offset 32 */
+    board_irq_body_d        /* body at line offset 48 */
+};
+
+
+void board_irq_service(unsigned long intid)
+{
+    unsigned int before;
+    unsigned int after;
+
+    /* A block of samples per placement, so each alignment is measured under the
+       same conditions rather than interleaved with the others.  */
+
+    {
+        unsigned int slot = board_service_count / BOARD_SAMPLES_EACH;
+
+        if (slot >= BOARD_ISR_PLACEMENTS)
+        {
+            slot = BOARD_ISR_PLACEMENTS - 1U;
+        }
+
+        before = timer_read_cycles();
+        board_irq_bodies[slot](intid);
+        after  = timer_read_cycles();
+    }
+
+    if (board_service_count < BOARD_LATENCY_SAMPLES)
+    {
+        board_service_cycles[board_service_count] = after - before;
+        board_service_count++;
+    }
 }
 
 


### PR DESCRIPTION
The handler comparison in #630 measured a single alignment — the same mistake that made this example's cache benchmark report 24% or 0% for identical silicon, and that invalidated a defect report to NXP. #631 fixed the cache probe; this applies the same treatment to the handler measurement and re-checks the ATCM claim under it.

## The claim survives

Mean cycles for the handler body, four placements at different offsets within a cache line:

| loop offset in line | code RAM | ATCM |
|---|---|---|
| 0 | 523 | 383 |
| 16 | 534 | 377 |
| 32 | 539 | 375 |
| 48 | 521 | 383 |

ATCM is faster at **every** placement, by about 28%, and the two sets of means do not overlap. Worst case improves as well: 510 against 694.

## Two things worth recording beyond the headline

**The handler measurement is only mildly alignment-sensitive** — 3.5% across placements in code RAM, 2% in ATCM — quite unlike the cache loop's two clean modes. So this comparison was less fragile than the cache one, and #630's direction was right even though its method was not defensible. Absolute numbers differ from #630 because the body now sits behind a placement wrapper that adds a call; the comparison is internally consistent either way.

**Both variants report identical cache sweeps** (0, 0, 240, 240), which settles the apparent regression that this branch's predecessor showed. That was the single-alignment probe moving between its two modes, not anything about ATCM. Worth stating explicitly, because I reported it as an ATCM regression at the time and it was not.

## Method

One copy of the logic is kept. The four wrappers inline a single `always_inline` implementation, so the placements cannot drift apart as the handler is edited. The timing wrapper stays in `.text` in both variants, so its own cost appears in every sample and cancels.

Samples are taken in blocks of 16 per placement rather than interleaved, so each alignment is measured under steady conditions.

## Verification

All three S32Z280 targets build clean with no warnings. Both images pass six of six boot probes.