### PR TITLE
Enabled BTCM, measured it, and put a ThreadX thread stack in it

### DIFF
--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/bsp_boot.c
@@ -256,9 +256,8 @@ static unsigned long cache_bench_words;
 
 #define MAKE_CACHE_WORKLOAD(name, pad_words)                                  \
 __attribute__((aligned(64), noinline))                                        \
-static void name(void)                                                        \
+static void name(volatile unsigned int *buffer)                               \
 {                                                                             \
-    volatile unsigned int  *buffer = (volatile unsigned int *) BUFFER_BASE;    \
     unsigned long           pass;                                             \
     unsigned long           i;                                                \
                                                                               \
@@ -278,7 +277,7 @@ MAKE_CACHE_WORKLOAD(cache_workload_b, 4)
 MAKE_CACHE_WORKLOAD(cache_workload_c, 8)
 MAKE_CACHE_WORKLOAD(cache_workload_d, 12)
 
-static void (*const cache_workloads[CACHE_WORKLOAD_COPIES])(void) =
+static void (*const cache_workloads[CACHE_WORKLOAD_COPIES])(volatile unsigned int *) =
 {
     cache_workload_a,       /* loop at line offset 0  */
     cache_workload_b,       /* loop at line offset 16 */
@@ -288,7 +287,7 @@ static void (*const cache_workloads[CACHE_WORKLOAD_COPIES])(void) =
 
 static void cache_workload(void)
 {
-    cache_workloads[0]();
+    cache_workloads[0]((volatile unsigned int *) BUFFER_BASE);
 }
 
 
@@ -529,6 +528,15 @@ void bsp_main(void)
             MARK(0x21);
             linflexd_puts("T3 preloading ATCM to establish ECC check bits\n");
             tcm_preload(0U, S32Z_ATCM_BASE, S32Z_ATCM_SIZE);
+
+            /* BTCM too, now that entry.S enables it.  Whole bank: nothing is
+               placed there at link time, and with ECC on, a location must be
+               written before it can be read.  BTCM accepts 32-bit stores where
+               ATCM needs 64-bit (TRM 6.2.2); tcm_preload handles the
+               difference.  */
+
+            linflexd_puts("T3b preloading BTCM\n");
+            tcm_preload(1U, S32Z_BTCM_BASE, S32Z_BTCM_SIZE);
 
             MARK(0x22);
             linflexd_puts("T4 write and read back ATCM\n");
@@ -851,51 +859,79 @@ void bsp_main(void)
     /* Measured at four loop alignments, not one, and the spread is reported
        because it is large and real.  See the comment on the workload copies.  */
 
-    linflexd_puts("C1 timing DRAM2 at four loop alignments\n");
+    /* Three memories, four loop alignments each.  The memories are the point:
+       DRAM2 runs at half the core frequency, DRAM0 at full, and BTCM at full
+       with zero wait states and no cache in the path at all -- an enabled TCM is
+       Non-cacheable Non-shareable Normal memory whatever the MPU says.
+
+       The alignment sweep is what makes the three comparable.  A single figure
+       per memory would be picking one of two modes per memory and calling it a
+       result, which is how this example previously produced a defect report that
+       had to be withdrawn.  */
+
+    linflexd_puts("C1 timing three memories, four loop alignments each\n");
     {
-        unsigned long gains[CACHE_WORKLOAD_COPIES];
-        unsigned long lo = 0xFFFFFFFFUL;
-        unsigned long hi = 0UL;
-        unsigned int  k;
-
-        for (k = 0U; k < CACHE_WORKLOAD_COPIES; k++)
+        static const struct
         {
-            unsigned long long  before;
-            unsigned long long  after;
-            unsigned long       cold;
-            unsigned long       warm;
+            const char     *name;
+            unsigned long   base;
+        } memories[3] =
+        {
+            { "DRAM2 half-speed", S32Z_DRAM2_BASE },
+            { "DRAM0 full-speed", S32Z_DRAM0_BASE + 0x10000UL },
+            { "BTCM  0 wait    ", S32Z_BTCM_BASE  }
+        };
 
-            /* Cold: both caches off.  cache_disable_all also invalidates, so
-               each alignment starts from the same state as the first.  */
+        unsigned long overall_hi = 0UL;
+        unsigned int  m;
 
-            cache_disable_all();
+        for (m = 0U; m < 3U; m++)
+        {
+            unsigned int k;
 
-            before = timer_read_cntpct();
-            cache_workloads[k]();
-            after  = timer_read_cntpct();
-            cold   = (unsigned long) (after - before);
-
-            cache_enable();
-
-            before = timer_read_cntpct();
-            cache_workloads[k]();
-            after  = timer_read_cntpct();
-            warm   = (unsigned long) (after - before);
-
-            gains[k] = (cold > warm) ? (((cold - warm) * 1000UL) / cold) : 0UL;
-
-            if (gains[k] < lo) { lo = gains[k]; }
-            if (gains[k] > hi) { hi = gains[k]; }
-
-            linflexd_puts("  offset ");
-            report_dec_small(k * 16U);
-            linflexd_puts(": cold ");
-            report_dec(cold);
-            linflexd_puts("  warm ");
-            report_dec(warm);
-            linflexd_puts("  gain/1000 ");
-            report_dec(gains[k]);
+            linflexd_puts("  ");
+            linflexd_puts(memories[m].name);
+            linflexd_puts(" at 0x");
+            linflexd_put_hex32((unsigned int) memories[m].base);
             linflexd_puts("\n");
+
+            for (k = 0U; k < CACHE_WORKLOAD_COPIES; k++)
+            {
+                volatile unsigned int *buf =
+                    (volatile unsigned int *) memories[m].base;
+                unsigned long long  before;
+                unsigned long long  after;
+                unsigned long       cold;
+                unsigned long       warm;
+                unsigned long       gain;
+
+                cache_disable_all();
+
+                before = timer_read_cntpct();
+                cache_workloads[k](buf);
+                after  = timer_read_cntpct();
+                cold   = (unsigned long) (after - before);
+
+                cache_enable();
+
+                before = timer_read_cntpct();
+                cache_workloads[k](buf);
+                after  = timer_read_cntpct();
+                warm   = (unsigned long) (after - before);
+
+                gain = (cold > warm) ? (((cold - warm) * 1000UL) / cold) : 0UL;
+                if (gain > overall_hi) { overall_hi = gain; }
+
+                linflexd_puts("    offset ");
+                report_dec((unsigned long) (k * 16U));
+                linflexd_puts(": cold ");
+                report_dec(cold);
+                linflexd_puts("  warm ");
+                report_dec(warm);
+                linflexd_puts("  gain/1000 ");
+                report_dec(gain);
+                linflexd_puts("\n");
+            }
         }
 
         MARK(0x72);
@@ -908,25 +944,19 @@ void bsp_main(void)
             linflexd_puts("C3 FAIL caches did not enable\n");
         }
 
-        report("gain lo  ", (unsigned int) lo);
-        report("gain hi  ", (unsigned int) hi);
+        /* The claim is that the caches can help somewhere, which needs one
+           memory at one alignment to show it.  BTCM is expected to show nothing:
+           it is not cached, so there is nothing for enabling the cache to
+           improve, and a zero there is the correct answer rather than a
+           failure.  */
 
-        /* The claim is that the caches can help this workload, which needs one
-           alignment to show it.  A criterion applied to a single arbitrary
-           alignment would report either 24% or nothing at all, and both would
-           be true of the same silicon.  */
-
-        if (hi >= 100UL)
+        if (overall_hi >= 100UL)
         {
-            linflexd_puts("C4 PASS caches measurably faster at some alignment\n");
-            if (lo < 100UL)
-            {
-                linflexd_puts("  note: alignment-dependent, low mode under 10%\n");
-            }
+            linflexd_puts("C4 PASS caches measurably faster somewhere\n");
         }
         else
         {
-            linflexd_puts("C4 no alignment showed a 10% speedup\n");
+            linflexd_puts("C4 no memory and alignment showed a 10% speedup\n");
         }
     }
 

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/demo_s32z280.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/demo_s32z280.c
@@ -57,6 +57,21 @@ static TX_THREAD    sleeper_thread;
 static TX_THREAD    spinner_thread;
 static TX_THREAD    judge_thread;
 
+/* One stack in BTCM, the rest in DRAM0, so a run exercises both and the
+   difference is visible if one of them is wrong.
+
+   BTCM is 16 KB at zero wait states and is never cached, whatever the MPU says
+   about it.  That is the point for a stack: access cost does not depend on
+   whether a line happens to be resident, which is what a determinism argument
+   needs.  Measured on this part, uncached BTCM comes within 6.6% of the best
+   cached case, where uncached DRAM0 is 22% off it.
+
+   entry.S writes every location in the bank before any C runs, which is
+   required before a read because ECC is enabled (TRM 6.2.2).  A stack is read
+   before it is written -- the first context restore pops what tx_thread_create
+   built -- so that preload is not optional here.  */
+
+__attribute__((section(".btcm_bss"), aligned(8)))
 static unsigned char sleeper_stack[DEMO_STACK_SIZE];
 static unsigned char spinner_stack[DEMO_STACK_SIZE];
 static unsigned char judge_stack[DEMO_STACK_SIZE];
@@ -190,6 +205,14 @@ static void judge_entry(ULONG input)
 void tx_application_define(void *first_unused_memory)
 {
     (void) first_unused_memory;
+
+    linflexd_puts("stacks: sleeper 0x");
+    linflexd_put_hex32((unsigned int) (unsigned long) sleeper_stack);
+    linflexd_puts(" (BTCM)  spinner 0x");
+    linflexd_put_hex32((unsigned int) (unsigned long) spinner_stack);
+    linflexd_puts("  judge 0x");
+    linflexd_put_hex32((unsigned int) (unsigned long) judge_stack);
+    linflexd_puts("\n");
 
     (void) tx_thread_create(&sleeper_thread, "sleeper", sleeper_entry, 0UL,
                             sleeper_stack, DEMO_STACK_SIZE,

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/entry.S
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/entry.S
@@ -260,6 +260,15 @@ start_a32:
 
     ldr     r0, =(0x30000000 | (0x07 << 2) | (1 << 8) | (1 << 1) | (1 << 0))
     mcr     p15, 0, r0, c9, c1, 0           /* IMP_ATCMREGIONR              */
+
+    /* BTCM as well.  16 KB at zero wait states, where ATCM has one, so it is the
+     * faster bank for data -- which is what it is wanted for here.  The claim
+     * that a second bank costs the data cache was withdrawn; see the note below.
+     * Preloaded by bsp_main before any read, as ECC requires, and BTCM accepts
+     * 32-bit stores where ATCM needs 64-bit (TRM 6.2.2).
+     */
+    ldr     r0, =(0x30100000 | (0x05 << 2) | (0 << 8) | (1 << 1) | (1 << 0))
+    mcr     p15, 0, r0, c9, c1, 1           /* IMP_BTCMREGIONR              */
     /* BTCM and CTCM are not enabled, because nothing in this example uses them.
      * That is the whole reason, and it is worth stating plainly because the
      * reason given here previously was wrong.

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/entry.S
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/entry.S
@@ -269,6 +269,24 @@ start_a32:
      */
     ldr     r0, =(0x30100000 | (0x05 << 2) | (0 << 8) | (1 << 1) | (1 << 0))
     mcr     p15, 0, r0, c9, c1, 1           /* IMP_BTCMREGIONR              */
+    isb
+
+    /* Preload the whole bank.  ECC is enabled on this part, so a TCM location
+     * must be written before it can be read (TRM 6.2.2), and this has to happen
+     * before any C runs: the demo images place thread stacks here and do not run
+     * bsp_boot.c, which is where the ATCM preload lives.  32-bit stores are
+     * sufficient for BTCM where ATCM needs 64-bit.
+     */
+
+    ldr     r1, =0x30100000
+    ldr     r2, =0x00004000
+    mov     r3, #0
+
+3:  str     r3, [r1], #4
+    subs    r2, r2, #4
+    bgt     3b
+
+    dsb     sy
     /* BTCM and CTCM are not enabled, because nothing in this example uses them.
      * That is the whole reason, and it is worth stating plainly because the
      * reason given here previously was wrong.

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/link.lds
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/link.lds
@@ -49,6 +49,11 @@ MEMORY
        placed here runs at full core speed with one wait state, where CODE is
        RTU code RAM and runs at half the core frequency (S32Z2 RM 6.3.6).  */
     ATCM (rwx) : ORIGIN = 0x30000000, LENGTH = 0x00010000    /* 64 KB  */
+    /* BTCM.  16 KB at zero wait states, enabled by entry.S, and preloaded there
+       as well because ECC means a location must be written before it is read.
+       Used for data that wants deterministic access without depending on a
+       cache -- an enabled TCM is never cached.  */
+    BTCM (rw)  : ORIGIN = 0x30100000, LENGTH = 0x00004000    /* 16 KB  */
     DATA (rwx) : ORIGIN = 0x31780000, LENGTH = 0x00080000    /* 512 KB: DRAM0 + DRAM1, both full core speed */
 }
 
@@ -129,6 +134,18 @@ SECTIONS
         . = ALIGN(8);
         __data_end__ = .;
     } > DATA
+
+    /* Data placed in BTCM.  NOLOAD: nothing is copied in, and entry.S has
+       already written every location in the bank to establish ECC check bits,
+       so anything here is safe to read before it is written by the program.  */
+
+    .btcm_bss (NOLOAD) : ALIGN(8)
+    {
+        __btcm_bss_start__ = .;
+        *(.btcm_bss*)
+        . = ALIGN(8);
+        __btcm_bss_end__ = .;
+    } > BTCM
 
     .bss (NOLOAD) :
     {

--- a/ports/cortex_r52/gnu/example_build/s32z280_evb/mpu.c
+++ b/ports/cortex_r52/gnu/example_build/s32z280_evb/mpu.c
@@ -388,7 +388,21 @@ static void build_table(void)
        AXIM provides there, which is not TCM and would read as success.  See the
        measurement in entry.S.  */
 
-    mpu_regions_used = 7U;
+    /* BTCM.  Data only, so execute-never, unlike the ATCM region above which
+       holds code.  An enabled TCM behaves as Non-cacheable Non-shareable Normal
+       memory whatever the MPU says, so the attribute index below describes the
+       permissions and nothing else -- but a region is still required before the
+       bank can be touched at all.  */
+
+    mpu_regions[7].mpu_region_base          = S32Z_BTCM_BASE;
+    mpu_regions[7].mpu_region_limit         = S32Z_BTCM_BASE + S32Z_BTCM_SIZE - 1UL;
+    mpu_regions[7].mpu_region_ap            = MPU_AP_RW_EL1;
+    mpu_regions[7].mpu_region_execute_never = 1U;
+    mpu_regions[7].mpu_region_shareability  = MPU_SH_NON;
+    mpu_regions[7].mpu_region_attr_index    = MPU_ATTR_NORMAL_WB;
+    mpu_regions[7].mpu_region_name          = "btcm  RW NX tcm";
+
+    mpu_regions_used = 8U;
 }
 
 


### PR DESCRIPTION
#630 put interrupt code in ATCM. This is the data side: BTCM enabled, characterised, and holding a real thread stack.

BTCM was disabled because of a regression that turned out not to exist — the claim was retracted in #633. Enabling it needs the region-register write at EL2, an MPU region, and an ECC preload before any read (TRM 6.2.2); all three patterns already existed for ATCM.

## What BTCM actually offers

The cache benchmark now sweeps three memories, four loop alignments each. At the alignments where the loop is not instruction-fetch bound:

| memory | cold (uncached) | warm (cached) | gain |
|---|---|---|---|
| DRAM2 half-speed | 857,540 | 651,436 | 24.0% |
| DRAM0 full-speed | 797,824 | 651,297 | 18.3% |
| **BTCM zero wait** | **694,689** | 651,369 | 6.2% |

Three things follow:

- **Warm times are identical across all three, within 0.02%.** Once the data cache is working, the backing store barely matters — the working set fits.
- **Cold times rank as the RM predicts**: BTCM, then DRAM0, then DRAM2 at half the core frequency (S32Z2 RM 6.3.6).
- **BTCM's residual 6.2% cannot be the data cache**, since an enabled TCM is Non-cacheable Non-shareable Normal memory whatever the MPU says. It is the instruction cache on the timing loop. This probe has always measured both caches together; three memories side by side is what makes that visible.

The number that matters for placing data there: **uncached BTCM is within 6.6% of the best cached case, where uncached DRAM0 is 22% off it.** Data in BTCM runs at close to cache-hit speed with no cache to miss.

DRAM2's sweep is unchanged with BTCM enabled (0, 0, 240, 240), independently confirming #633's retraction.

## The stack

One of the demo's three stacks moves to BTCM; the other two stay in DRAM0, so a run exercises both and a mistake in either shows.

`link.lds` gains a BTCM region and a `.btcm_bss` NOLOAD section, so the stack is an ordinary C array with a section attribute and the linker checks it fits — rather than a hardcoded address that would silently overflow a 16 KB bank.

`entry.S` preloads the whole bank at EL2, and this is **not optional**: a stack is read before the program writes it, because the first context restore pops what `tx_thread_create` built into it. With ECC enabled, reading an unwritten TCM location faults. It must happen before any C runs, since the demo images do not execute `bsp_boot.c` where the ATCM preload lives.

## What this does not claim

**No thread-level timing improvement has been measured.** The case rests on the memory characterisation above and on removing the cache from the path, not on a context-switch figure. That measurement is worth doing and hasn't been done.

## Verification

The demo prints its stack addresses so placement is visible rather than implied — sleeper at `0x30100000` in BTCM, spinner and judge in DRAM0 — and passes with 100 ticks, 20 sleeper wakeups and 20 preemptions. A real thread schedules, preempts and context-switches on a tightly-coupled-memory stack. Boot image still passes six of six probes; all three targets build clean.