### PR TITLE
Bounded the wait in the thread priority change regression tests

### DIFF
--- a/test/smp/regression/threadx_thread_priority_change.c
+++ b/test/smp/regression/threadx_thread_priority_change.c
@@ -513,6 +513,15 @@ static void    thread_3_entry(ULONG thread_input)
 UINT    old_priority;
 UINT    loop;
 
+/* The interrupt below only fires on a narrow window: thread 3 at priority 6,
+   ready, and not yet at the head of its priority list. Waiting for it without a
+   bound made this test hang indefinitely when the window was never hit, which
+   showed up in CI as a timeout carrying no information about what went wrong.
+   The TX_NOT_INTERRUPTABLE path already stopped after a fixed amount of work;
+   this gives the interruptable path the same protection.  */
+UINT    attempts = 0;
+#define MAX_PRIORITY_CHANGE_ATTEMPTS  100000
+
 
     /* Resume threads 4.  */
     tx_thread_resume(&thread_4);
@@ -537,7 +546,23 @@ UINT    loop;
         if (thread_4_counter)
             thread_1_counter++;
 
-    } while (test_isr_dispatch);
+        attempts++;
+
+    } while (test_isr_dispatch && (attempts < MAX_PRIORITY_CHANGE_ATTEMPTS));
+
+    /* Stop the interrupt regardless, so a window that was never hit does not
+       leave the handler installed for the rest of the test.  */
+    test_isr_dispatch =  TX_NULL;
+
+    if (attempts >= MAX_PRIORITY_CHANGE_ATTEMPTS)
+    {
+
+        /* The window was not reached. That is a gap in what this test covered on
+           this run rather than a fault in the code under test, so say so instead
+           of failing, and leave the counters alone so the checks that follow
+           still mean what they did before.  */
+        printf("(priority change window not reached in %u attempts) ", attempts);
+    }
 }
 
 

--- a/test/tx/regression/threadx_thread_priority_change.c
+++ b/test/tx/regression/threadx_thread_priority_change.c
@@ -354,6 +354,15 @@ static void    thread_3_entry(ULONG thread_input)
 UINT    old_priority;
 UINT    loop;
 
+/* The interrupt below only fires on a narrow window: thread 3 at priority 6,
+   ready, and not yet at the head of its priority list. Waiting for it without a
+   bound made this test hang indefinitely when the window was never hit, which
+   showed up in CI as a timeout carrying no information about what went wrong.
+   The TX_NOT_INTERRUPTABLE path already stopped after a fixed amount of work;
+   this gives the interruptable path the same protection.  */
+UINT    attempts = 0;
+#define MAX_PRIORITY_CHANGE_ATTEMPTS  100000
+
 
     /* Resume threads 4.  */
     tx_thread_resume(&thread_4);
@@ -378,7 +387,23 @@ UINT    loop;
         if (thread_4_counter)
             thread_1_counter++;
 
-    } while (test_isr_dispatch);
+        attempts++;
+
+    } while (test_isr_dispatch && (attempts < MAX_PRIORITY_CHANGE_ATTEMPTS));
+
+    /* Stop the interrupt regardless, so a window that was never hit does not
+       leave the handler installed for the rest of the test.  */
+    test_isr_dispatch =  TX_NULL;
+
+    if (attempts >= MAX_PRIORITY_CHANGE_ATTEMPTS)
+    {
+
+        /* The window was not reached. That is a gap in what this test covered on
+           this run rather than a fault in the code under test, so say so instead
+           of failing, and leave the counters alone so the checks that follow
+           still mean what they did before.  */
+        printf("(priority change window not reached in %u attempts) ", attempts);
+    }
 }
 
 


### PR DESCRIPTION
The SMP regression suite has been red since 30 June. This is why.

## The defect

Both copies of `threadx_thread_priority_change` — `test/smp/regression/` and `test/tx/regression/` — install an interrupt handler and then spin until it clears a flag:

```c
    test_isr_dispatch =  test_isr;
    do
    {
        loop =  rand() % 100;
        while (loop--) { thread_3_counter++; }

        tx_thread_priority_change(&thread_3, 6, &old_priority);
        tx_thread_priority_change(&thread_3, 5, &old_priority);
        ...
    } while (test_isr_dispatch);          /* only the handler ends this */
```

The handler clears it only on a narrow window — thread 3 at priority 6, ready, and **not yet at the head of its priority list**, a state that exists only part way through a priority change:

```c
    if ((thread_3.tx_thread_priority == 6) &&
        (thread_3.tx_thread_state == TX_READY) &&
        (_tx_thread_priority_list[6] != &thread_3) &&
        (thread_3_counter > 100))
```

If an interrupt never lands inside that window, the loop never ends. There was no iteration cap and no fallback.

Notably, the `TX_NOT_INTERRUPTABLE` branch of the same handler *does* stop after a fixed amount of work. Only the interruptable path — the one the failing configuration uses — had no protection.

## Why this is a hang and not slow work

Worth being precise, because "test timed out" usually means "make the timeout bigger":

- the test carries **no per-test `TIMEOUT` property**, so ctest's `--timeout 1000` applies — a thousand seconds
- locally it finishes in **0.12s median**, worst case 0.29s over thirty runs
- it survived `--repeat until-pass:2`, so it hung **twice in succession**

Nothing turns 0.12 seconds into more than a thousand. It is an unbounded wait that was never satisfied.

It is also the dominant cause of the red suite: it times out in **three of the last four failing runs**, always in a stack-checking configuration.

## The change

Cap the loop, and clear the handler on the way out so an unreached window does not leave it installed for the rest of the test.

When the window is not reached the test reports it and still passes. Not reaching it is a gap in what that run covered, not a fault in the code under test, and failing would report a defect that does not exist. The counters are left untouched so the checks that follow keep their previous meaning.

The cap is 100000 attempts. An exhausted cap takes about 60 seconds, measured; a successful run takes 0.12 seconds. That puts the usual cost near two hundred attempts and leaves the cap about two orders of magnitude clear — wide enough not to lose coverage on a slower machine, while replacing a timeout that says nothing with a message that says what happened.

Both copies are fixed. The non-SMP one has the identical unbounded wait and has simply been luckier.

## Verification

**The fix does what it claims.** With the handler's window deliberately made unreachable, the test previously ran until killed; now it exits in about a minute reporting that the window was not reached. Restored, it passes 10 of 10.

**No regression.** The full SMP suite passes **110 of 110** at the parallelism CI uses (`ctest -j18 --timeout 1000 --repeat until-pass:2`), in 13 seconds.

**Not reproducible here, which fits the diagnosis rather than contradicting it.** On sixteen cores the window is hit almost immediately. All of these came back clean: thirty sequential runs; two hundred runs at parallelism thirty-two; sixty runs pinned to two CPUs; forty pinned to a single CPU; three full-suite passes at CI parallelism. The defect is the *reliance* on the window, not any particular machine — which is also why a four-vCPU runner with four simulated SMP cores can miss it indefinitely.

## Known, and deliberately not addressed here

One older failure in the history is a different problem: `threadx_semaphore_timeout_test`, `threadx_timer_information_test` and `threadx_timer_simple_test` failed together in the `tx` suite in run 27124024638. All three assert exact tick values — `now != 33` (CI observed 34), and `timer_0_counter != 23 || tx_time_get() != 120` in the other two. A single slipped tick on the hosted port fails all three at once, which explains the clustering.

Those assertions are doing their job: exact-tick behaviour is a real RTOS property and precisely what a regression test should pin. Loosening them would make the suite green while blinding it to genuine off-by-one timing regressions. That cluster appeared once in recent history against three of four for this hang, so it is left as a known flake pending evidence that it recurs.
