### PR TITLE
Stopped a stalled install from costing a whole regression run

### DIFF
--- a/.github/workflows/regression_template.yml
+++ b/.github/workflows/regression_template.yml
@@ -67,13 +67,20 @@ jobs:
       with:
         submodules: true
 
+    # apt and PyPI have stalled this step twice, for 55 minutes and for over two
+    # hours, against a normal 27 to 152 seconds. Nothing here had a timeout, so a
+    # stall ran until the six hour job limit and cost a whole run rather than
+    # failing and being retried.
     - name: Install softwares
+      timeout-minutes: 10
       run: ${{ inputs.install_script }}
 
     - name: Build
+      timeout-minutes: 15
       run: ${{ inputs.build_script }}
 
     - name: Test
+      timeout-minutes: 60
       run: ${{ inputs.test_script }}
 
     - name: Publish Test Results


### PR DESCRIPTION
No step in `regression_template.yml` has a timeout, so a stalled step runs until the six hour job limit.

## What stalled

The `Install softwares` step runs `apt-get update`, an `apt-get install` and a `pip install`. It has stalled twice:

| run | job | time in the install step |
|---|---|---|
| one run | SMP | 55 minutes |
| the next run | ThreadX | more than 2 hours |
| every other run measured | both | 27 to 152 seconds |

In the second case the tests never started at all.

Two things go wrong when this happens. A transient apt or PyPI problem costs a whole run, and the failure that eventually gets reported says nothing about which step was stuck — the job simply sits there.

## The change

Bound the three steps that do real work, each well clear of its observed worst case:

| step | timeout | observed range |
|---|---|---|
| Install softwares | 10 min | 27–152 s |
| Build | 15 min | 4–54 s |
| Test | 60 min | longest 37 min |

The test step is the only one whose length depends on the suites themselves, and that 37 minute observation was taken with an unbounded wait in one test that has since been bounded.

A step that trips its timeout fails and names itself, which is the point. None of these numbers is tight enough to trip on work that is merely slow.

## What this does not do

A timeout reports a stall; it does not prevent one. The install step stalling on a dead apt mirror is addressed separately, by bounding and retrying each fetch inside `install.sh`. This change is what makes that stall visible and cheap in the meantime, and it is what caught the mirror failure in the first place: five of the seven `apt-get update` stalls recorded in a single day were terminated by this ten minute bound rather than by the job limit.
