### PR TITLE
Ran the ThreadX and SMP regression suites one test at a time

### DIFF
--- a/scripts/test_smp.sh
+++ b/scripts/test_smp.sh
@@ -11,4 +11,4 @@
 ##############################################################################
 
 
-CTEST_PARALLEL_LEVEL=4 $(dirname `realpath $0`)/../test/smp/cmake/run.sh test all
+CTEST_PARALLEL_LEVEL=1 $(dirname `realpath $0`)/../test/smp/cmake/run.sh test all

--- a/scripts/test_tx.sh
+++ b/scripts/test_tx.sh
@@ -11,4 +11,4 @@
 ##############################################################################
 
 
-CTEST_PARALLEL_LEVEL=4 $(dirname `realpath $0`)/../test/tx/cmake/run.sh test all
+CTEST_PARALLEL_LEVEL=1 $(dirname `realpath $0`)/../test/tx/cmake/run.sh test all


### PR DESCRIPTION
A large part of both suites sleeps and then asserts on the tick counter, either exactly or within a tick:

```c
    tx_thread_sleep(18);
    now =  tx_time_get();
    if ((now == 18) || (now == 19))
```

The Linux port drives ticks from a thread running under `SCHED_FIFO`, so ticks keep arriving whether or not the thread waiting on them can get a core. Starve that thread and further ticks land between the sleep expiring and the read, the value is past the one asked for, and a kernel that behaved correctly is reported as broken.

**Thirty-five tests** in the ThreadX suite and **forty-one** on the SMP side sleep and then consult the clock, or a counter driven by it. This is most of the suite rather than a corner of it.

## The starvation is self-inflicted

Four tests run at once on a four vCPU runner. Each one is a process carrying a scheduler thread, a `SCHED_FIFO` timer thread and a thread of its own, so the machine is oversubscribed two or three times over by design.

That is why three of these failed in the run of 18 August, and why the retry hid two of them.

## Naming the sensitive tests does not converge

Keeping the sensitive tests apart with `RUN_SERIAL` was tried first:

- a list covering the tests comparing `tx_time_get()` for equality missed `threadx_timer_multiple_accuracy_test`, which compares timer-driven counters — CI failed on it
- widening the list to cover those missed `threadx_thread_sleep_for_100ticks_test`, which asserts a range rather than an equality — CI failed on that

A list that is quietly incomplete is worse than no list, because it reads as protection.

## The change

Stop overlapping the tests. `CTEST_PARALLEL_LEVEL` goes from 4 to 1 in `test_tx.sh` and `test_smp.sh`.

Serial execution removes the contention for every test at once, needs nothing to be enumerated, and makes a run reproducible: a test either passes on its own machine or has a real defect.

It also makes the tick budget in `threadx_thread_wait_abort_and_isr_test` mean what it says. Under contention that test took 255 seconds while its 20000 tick budget never engaged, because the ticks themselves stretch when the process cannot get a core. With nothing else running, ticks track wall clock and a budget in ticks bounds elapsed time.

## The cost, and why it is worth paying

Measured in a four CPU cpuset, per configuration:

| suite | parallel 4 | serial |
|---|---|---|
| ThreadX | 12.2 s | 47.6 s |
| SMP | 15.2 s | 60.0 s |

Close to a factor of four. The suites parallelise almost perfectly, so that factor is exactly what parallelism was buying.

Set against what it replaces: the run this supersedes spent **36 minutes** and reported a timeout carrying no information, and 2000 of those seconds went on retrying a test that had already hung twice. In CI, with the unbounded waits in these suites now bounded, the serial ThreadX and SMP jobs complete in about ten minutes each — five configurations apiece, 96 of 96 and 110 of 110.

## Scope

The FreeRTOS suite is left alone. It covers the creation paths of the compatibility layer and has no tick accuracy tests, so it has nothing to gain here.
