### PR TITLE
Gave the wait abort ISR test a budget instead of an open-ended wait

### DIFF
--- a/test/smp/regression/threadx_thread_wait_abort_and_isr_test.c
+++ b/test/smp/regression/threadx_thread_wait_abort_and_isr_test.c
@@ -12,6 +12,7 @@
 /* This test is designed to test for simultaneous thread suspension lifting AND thread wait abort calls.  */
 
 #include   <stdio.h>
+#include   <time.h>
 #include   "tx_api.h"
 #include   "tx_timer.h"
 
@@ -178,6 +179,24 @@ static void    thread_0_entry(ULONG thread_input)
 
 UINT    status;
 
+/* The window this test waits for is probabilistic, and the handler above says
+   as much: it can settle into a resonance in which the condition is never met.
+   Waiting for it without a bound means such a run never ends, and this test has
+   been the most expensive thing in the suite: run one at a time in CI it took
+   between 148 and 726 seconds per configuration, 88 percent of the whole
+   ThreadX suite, against 273 seconds for the other ninety five tests together.
+
+   The budget is in wall clock seconds rather than ticks on purpose. The
+   simulated tick clock is not a proxy for elapsed time here: a tick arrives only
+   when the port's timer thread gets to run, so under load, or under coverage
+   instrumentation, ticks fall behind and never catch up. A budget of 20000
+   ticks, nominally 200 seconds, failed to stop a run that took 726 seconds,
+   because fewer than 20000 ticks had passed. time() does not drift that way.  */
+#define WAIT_ABORT_WINDOWS_WANTED   ((ULONG) 20)
+#define WAIT_ABORT_SECOND_BUDGET    ((ULONG) 120)
+
+time_t  start_wall;
+
 
     /* Setup ISR for this test.  */
     test_isr_dispatch =  isr_entry;
@@ -186,7 +205,8 @@ UINT    status;
     printf("Running Thread Wait Abort and ISR Resume Test....................... ");
 
     /* Loop to exploit the probability window inside tx_thread_wait_abort.  */
-    while (condition_count < 20)
+    start_wall =  time(TX_NULL);
+    while (condition_count < WAIT_ABORT_WINDOWS_WANTED)
     {
 
         /* Suspend on the semaphore that is going to be set via the ISR.  */
@@ -227,10 +247,25 @@ UINT    status;
 #endif
 
         }
+
+        /* Out of budget?  */
+        if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_SECOND_BUDGET)
+            break;
     }
 
     /* Clear ISR dispatch.  */
     test_isr_dispatch =  TX_NULL;
+
+    if (condition_count < WAIT_ABORT_WINDOWS_WANTED)
+    {
+
+        /* Say what this run reached. Falling short is a gap in what was
+           exercised rather than a fault in the code under test, so the check
+           below still runs and still means what it did.  */
+        printf("(reached %lu of %lu windows in %lu seconds) ",
+               (ULONG) condition_count, WAIT_ABORT_WINDOWS_WANTED,
+               (ULONG) (time(TX_NULL) - start_wall));
+    }
 
 #ifdef TX_NOT_INTERRUPTABLE
     /* At this point, check to see if we got all the semaphores!  */

--- a/test/tx/regression/threadx_thread_wait_abort_and_isr_test.c
+++ b/test/tx/regression/threadx_thread_wait_abort_and_isr_test.c
@@ -12,6 +12,7 @@
 /* This test is designed to test for simultaneous thread suspension lifting AND thread wait abort calls.  */
 
 #include   <stdio.h>
+#include   <time.h>
 #include   "tx_api.h"
 
 static unsigned long   thread_0_counter =  0;
@@ -177,6 +178,24 @@ static void    thread_0_entry(ULONG thread_input)
 
 UINT    status;
 
+/* The window this test waits for is probabilistic, and the handler above says
+   as much: it can settle into a resonance in which the condition is never met.
+   Waiting for it without a bound means such a run never ends, and this test has
+   been the most expensive thing in the suite: run one at a time in CI it took
+   between 148 and 726 seconds per configuration, 88 percent of the whole
+   ThreadX suite, against 273 seconds for the other ninety five tests together.
+
+   The budget is in wall clock seconds rather than ticks on purpose. The
+   simulated tick clock is not a proxy for elapsed time here: a tick arrives only
+   when the port's timer thread gets to run, so under load, or under coverage
+   instrumentation, ticks fall behind and never catch up. A budget of 20000
+   ticks, nominally 200 seconds, failed to stop a run that took 726 seconds,
+   because fewer than 20000 ticks had passed. time() does not drift that way.  */
+#define WAIT_ABORT_WINDOWS_WANTED   ((ULONG) 10)
+#define WAIT_ABORT_SECOND_BUDGET    ((ULONG) 120)
+
+time_t  start_wall;
+
 
     /* Setup ISR for this test.  */
     test_isr_dispatch =  isr_entry;
@@ -185,7 +204,8 @@ UINT    status;
     printf("Running Thread Wait Abort and ISR Resume Test....................... ");
 
     /* Loop to exploit the probability window inside tx_thread_wait_abort.  */
-    while (condition_count < 10)
+    start_wall =  time(TX_NULL);
+    while (condition_count < WAIT_ABORT_WINDOWS_WANTED)
     {
 
         /* Suspend on the semaphore that is going to be set via the ISR.  */
@@ -226,10 +246,25 @@ UINT    status;
 #endif
 
         }
+
+        /* Out of budget?  */
+        if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_SECOND_BUDGET)
+            break;
     }
 
     /* Clear ISR dispatch.  */
     test_isr_dispatch =  TX_NULL;
+
+    if (condition_count < WAIT_ABORT_WINDOWS_WANTED)
+    {
+
+        /* Say what this run reached. Falling short is a gap in what was
+           exercised rather than a fault in the code under test, so the check
+           below still runs and still means what it did.  */
+        printf("(reached %lu of %lu windows in %lu seconds) ",
+               (ULONG) condition_count, WAIT_ABORT_WINDOWS_WANTED,
+               (ULONG) (time(TX_NULL) - start_wall));
+    }
 
 #ifdef TX_NOT_INTERRUPTABLE
     /* At this point, check to see if we got all the semaphores!  */


### PR DESCRIPTION
`threadx_thread_wait_abort_and_isr_test` waits for an interrupt to land while the preempt disable flag is set, and waits for it ten times — twenty in the SMP copy — with no bound on how long that takes.

The handler in the same file already says what can go wrong:

> It is possible for this test to get into a resonance condition in which the ISR never occurs while preemption is disabled

and it perturbs its own duration to break out of that. That helps but guarantees nothing, and if the resonance holds, the loop does not end.

## It is also the most expensive thing in either suite

Run one test at a time in CI, per configuration it took between **148 and 726 seconds**:

| | time |
|---|---|
| this test, five configurations | 1936 s |
| the other ninety five tests together | 273 s |
| ThreadX suite total | 2209 s |

Nothing else in the suite is within two orders of magnitude of it.

## The budget is in wall clock seconds, not ticks

That distinction turned out to matter. A tick is delivered only when the port's timer thread gets to run, so the simulated clock falls behind real time under load or under coverage instrumentation, and never makes the loss up.

A first attempt bounded the wait at 20000 ticks, nominally 200 seconds. It failed to stop a run that took 726 seconds, because fewer than 20000 ticks had gone by. `tx_time_get()` cannot bound elapsed time here; `time()` can.

## What a short run reports

A run that falls short says how many windows it reached rather than going quiet, and the check after the loop is untouched. That check compares semaphore bookkeeping which holds whatever number of windows were hit, so it still means exactly what it did before.

Hitting the race a few times rather than ten is a smaller loss than it looks. The value is in reaching the window at all; the later hits repeat what the first ones established.

## Verification

**The budget engages.** Forced to 3 seconds, the test stops after 3.14 seconds of wall clock and reports reaching 0 of 10 windows, with the following check intact.

**No regression.** At the 120 second budget, both suites pass every configuration run serially.

Both copies are fixed — `test/tx/regression/` and `test/smp/regression/` — since the wait is identical in each.
