### PR TITLE
Asked the wait abort test for three windows, and failed a run that reached none

### DIFF
--- a/test/smp/regression/threadx_thread_wait_abort_and_isr_test.c
+++ b/test/smp/regression/threadx_thread_wait_abort_and_isr_test.c
@@ -191,9 +191,39 @@ UINT    status;
    when the port's timer thread gets to run, so under load, or under coverage
    instrumentation, ticks fall behind and never catch up. A budget of 20000
    ticks, nominally 200 seconds, failed to stop a run that took 726 seconds,
-   because fewer than 20000 ticks had passed. time() does not drift that way.  */
+   because fewer than 20000 ticks had passed. time() does not drift that way.
+
+   How many windows to ask for is set by what a run can actually reach. Four CI
+   runs of the same tree measured this loop in two modes: one where a window
+   arrives in milliseconds and every window asked for costs under a second in
+   total, and one where a single window costs around forty seconds. Seven of
+   twenty configuration-runs landed in the slow mode and ran out of budget,
+   reaching 0, 3, 3, 3, 4, 7 and 7 of the ten then asked for, every one of them
+   still reporting a pass. Asking for three keeps the count reachable in both
+   modes. The later hits repeat what the first ones establish, so the coverage
+   given up is small, and what is recorded is honest. This copy reaches its
+   twenty windows in under half a second in all five of its configurations, so
+   it keeps that count; the non-SMP copy, where the slow mode was measured, asks
+   for three.
+
+   Reaching the window no times at all is different in kind, which is what the
+   ceiling below is for. The check after the loop compares semaphore bookkeeping
+   that a window has to have touched to mean anything, so a pass with a count of
+   zero claims coverage the run did not have. One of those twenty runs did
+   exactly that, and said so only in an artifact nobody reads. A run that has not
+   reached the window once keeps trying up to the ceiling, and fails if it still
+   has not.
+
+   The budget is 180 seconds rather than 120 because of what the slow mode costs
+   per window. The seven truncated runs reached their windows at between 17 and
+   40 seconds each, so three of them can need 120 seconds, which is exactly what
+   the old budget allowed and would have truncated at two. 180 leaves margin at
+   the worst rate measured, and bounds five configurations at 15 minutes against
+   a 60 minute step timeout. Locally, where a window costs 2 to 5 seconds, three
+   of them take 5 to 14 seconds and the budget is never approached.  */
 #define WAIT_ABORT_WINDOWS_WANTED   ((ULONG) 20)
-#define WAIT_ABORT_SECOND_BUDGET    ((ULONG) 120)
+#define WAIT_ABORT_SECOND_BUDGET    ((ULONG) 180)
+#define WAIT_ABORT_ZERO_WINDOW_CEILING  ((ULONG) 300)
 
 time_t  start_wall;
 
@@ -248,24 +278,46 @@ time_t  start_wall;
 
         }
 
-        /* Out of budget?  */
+        /* Out of budget?  A run that has not reached the window even once has
+           verified nothing yet, so it gets the higher ceiling before giving up.  */
+#ifdef TX_NOT_INTERRUPTABLE
         if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_SECOND_BUDGET)
             break;
+#else
+        if (condition_count == 0)
+        {
+            if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_ZERO_WINDOW_CEILING)
+                break;
+        }
+        else if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_SECOND_BUDGET)
+            break;
+#endif
     }
 
     /* Clear ISR dispatch.  */
     test_isr_dispatch =  TX_NULL;
 
-    if (condition_count < WAIT_ABORT_WINDOWS_WANTED)
+    /* Say what this run reached, on every run and not only a short one. A count
+       printed only on shortfall cannot be told apart from a count nobody
+       recorded, and this line is what the CI artifacts carry. Falling short is a
+       gap in what was exercised rather than a fault in the code under test, so
+       the check below still runs and still means what it did.  */
+    printf("(reached %lu of %lu windows in %lu seconds) ",
+           (ULONG) condition_count, WAIT_ABORT_WINDOWS_WANTED,
+           (ULONG) (time(TX_NULL) - start_wall));
+
+#ifndef TX_NOT_INTERRUPTABLE
+
+    /* Reached it no times?  Then the check below compares bookkeeping no window
+       ever touched, and a pass would report coverage this run did not have.  */
+    if (condition_count == 0)
     {
 
-        /* Say what this run reached. Falling short is a gap in what was
-           exercised rather than a fault in the code under test, so the check
-           below still runs and still means what it did.  */
-        printf("(reached %lu of %lu windows in %lu seconds) ",
-               (ULONG) condition_count, WAIT_ABORT_WINDOWS_WANTED,
-               (ULONG) (time(TX_NULL) - start_wall));
+        /* Test error!  */
+        printf("ERROR #8\n");
+        test_control_return(4);
     }
+#endif
 
 #ifdef TX_NOT_INTERRUPTABLE
     /* At this point, check to see if we got all the semaphores!  */

--- a/test/tx/regression/threadx_thread_wait_abort_and_isr_test.c
+++ b/test/tx/regression/threadx_thread_wait_abort_and_isr_test.c
@@ -190,9 +190,38 @@ UINT    status;
    when the port's timer thread gets to run, so under load, or under coverage
    instrumentation, ticks fall behind and never catch up. A budget of 20000
    ticks, nominally 200 seconds, failed to stop a run that took 726 seconds,
-   because fewer than 20000 ticks had passed. time() does not drift that way.  */
-#define WAIT_ABORT_WINDOWS_WANTED   ((ULONG) 10)
-#define WAIT_ABORT_SECOND_BUDGET    ((ULONG) 120)
+   because fewer than 20000 ticks had passed. time() does not drift that way.
+
+   How many windows to ask for is set by what a run can actually reach. Four CI
+   runs of the same tree measured this loop in two modes: one where a window
+   arrives in milliseconds and every window asked for costs under a second in
+   total, and one where a single window costs around forty seconds. Seven of
+   twenty configuration-runs landed in the slow mode and ran out of budget,
+   reaching 0, 3, 3, 3, 4, 7 and 7 of the ten then asked for, every one of them
+   still reporting a pass. Asking for three keeps the count reachable in both
+   modes. The later hits repeat what the first ones establish, so the coverage
+   given up is small, and what is recorded is honest. The SMP copy asks for
+   twenty and reaches them in under half a second in all five of its
+   configurations, so it keeps its count.
+
+   Reaching the window no times at all is different in kind, which is what the
+   ceiling below is for. The check after the loop compares semaphore bookkeeping
+   that a window has to have touched to mean anything, so a pass with a count of
+   zero claims coverage the run did not have. One of those twenty runs did
+   exactly that, and said so only in an artifact nobody reads. A run that has not
+   reached the window once keeps trying up to the ceiling, and fails if it still
+   has not.
+
+   The budget is 180 seconds rather than 120 because of what the slow mode costs
+   per window. The seven truncated runs reached their windows at between 17 and
+   40 seconds each, so three of them can need 120 seconds, which is exactly what
+   the old budget allowed and would have truncated at two. 180 leaves margin at
+   the worst rate measured, and bounds five configurations at 15 minutes against
+   a 60 minute step timeout. Locally, where a window costs 2 to 5 seconds, three
+   of them take 5 to 14 seconds and the budget is never approached.  */
+#define WAIT_ABORT_WINDOWS_WANTED   ((ULONG) 3)
+#define WAIT_ABORT_SECOND_BUDGET    ((ULONG) 180)
+#define WAIT_ABORT_ZERO_WINDOW_CEILING  ((ULONG) 300)
 
 time_t  start_wall;
 
@@ -247,24 +276,46 @@ time_t  start_wall;
 
         }
 
-        /* Out of budget?  */
+        /* Out of budget?  A run that has not reached the window even once has
+           verified nothing yet, so it gets the higher ceiling before giving up.  */
+#ifdef TX_NOT_INTERRUPTABLE
         if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_SECOND_BUDGET)
             break;
+#else
+        if (condition_count == 0)
+        {
+            if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_ZERO_WINDOW_CEILING)
+                break;
+        }
+        else if (((ULONG) (time(TX_NULL) - start_wall)) > WAIT_ABORT_SECOND_BUDGET)
+            break;
+#endif
     }
 
     /* Clear ISR dispatch.  */
     test_isr_dispatch =  TX_NULL;
 
-    if (condition_count < WAIT_ABORT_WINDOWS_WANTED)
+    /* Say what this run reached, on every run and not only a short one. A count
+       printed only on shortfall cannot be told apart from a count nobody
+       recorded, and this line is what the CI artifacts carry. Falling short is a
+       gap in what was exercised rather than a fault in the code under test, so
+       the check below still runs and still means what it did.  */
+    printf("(reached %lu of %lu windows in %lu seconds) ",
+           (ULONG) condition_count, WAIT_ABORT_WINDOWS_WANTED,
+           (ULONG) (time(TX_NULL) - start_wall));
+
+#ifndef TX_NOT_INTERRUPTABLE
+
+    /* Reached it no times?  Then the check below compares bookkeeping no window
+       ever touched, and a pass would report coverage this run did not have.  */
+    if (condition_count == 0)
     {
 
-        /* Say what this run reached. Falling short is a gap in what was
-           exercised rather than a fault in the code under test, so the check
-           below still runs and still means what it did.  */
-        printf("(reached %lu of %lu windows in %lu seconds) ",
-               (ULONG) condition_count, WAIT_ABORT_WINDOWS_WANTED,
-               (ULONG) (time(TX_NULL) - start_wall));
+        /* Test error!  */
+        printf("ERROR #8\n");
+        test_control_return(4);
     }
+#endif
 
 #ifdef TX_NOT_INTERRUPTABLE
     /* At this point, check to see if we got all the semaphores!  */


### PR DESCRIPTION
`threadx_thread_wait_abort_and_isr_test` was given a wall clock budget in #644 so an unreachable race window could not hang a run. Four runs of the same tree since then show the budget being reached far more often than the first green run suggested, and a pass being reported every time it was.

## The measurements

Twenty configuration-runs of the non-SMP copy. Seven ran out of budget:

| configuration | windows reached | elapsed |
|---|---|---|
| trace_build | 3 of 10 | 121 s |
| disable_notify_callbacks | 3 of 10 | 121 s |
| default_build_coverage | 4 of 10 | 121 s |
| stack_checking | 7 of 10 | 121 s |
| trace_build | **0 of 10** | 121 s |
| disable_notify_callbacks | 7 of 10 | 121 s |
| stack_checking | 3 of 10 | 121 s |

Every one of those reported a pass, and the shortfall message reaches only the uploaded artifact — ctest runs with `--output-on-failure`, so a passing test's output is not in the job log at all. The suite has been losing most of this test's coverage in whole configurations, in three of them at once, and reporting green.

## Ten windows are not reachable inside any sensible budget

The loop runs in two modes rather than one, with nothing in between across those twenty runs:

- **fast** — a window arrives in milliseconds; ten of them cost under a second
- **slow** — a window costs between 17 and 40 seconds

Ten windows in the slow mode is 400 seconds at the worst rate, and the unbounded runs measured before #644 reached 726. Raising the budget far enough to cover that would put five configurations within reach of the sixty minute step timeout added in #641 — trading a quiet loss of coverage for a loud timeout risk.

## The change

**Ask for what a run can reach.** `WAIT_ABORT_WINDOWS_WANTED` goes from 10 to 3 in the non-SMP copy. Three windows cost 51 to 120 seconds in the slow mode and under a second in the fast one. The rationale committed with #644 applies directly: the value is in reaching the window at all, and the later hits repeat what the first ones establish.

**Budget 120 → 180 seconds.** Three windows at the worst rate measured is exactly the 120 it was, which would have truncated at two.

**Report the count on every run**, not only on a short one. A number that appears only on shortfall cannot be told apart from a number nobody recorded.

**Reaching no window at all now fails.** That case is different in kind from falling short: the check after the loop compares semaphore bookkeeping that a window has to have touched to mean anything, so a run that reached none compares a counter against the value it was initialised to and reports a pass having verified nothing. Such a run keeps trying to a 300 second ceiling and fails with `ERROR #8` if it still has not reached the window. A resonance that holds for five minutes is worth a failure.

**The SMP copy keeps its count of twenty.** It reaches them in under half a second in all five of its configurations across all four runs, so the slow mode has never been observed there and that coverage is free. Both copies get the ceiling and the unconditional report, so the logic stays identical between them — the divergence in #648 was a reminder of what happens when it does not.

## Verification

**In CI, in the slow mode.** The verification run happened to land in the slow mode, which is the case that matters, and every configuration reached full coverage inside the new budget:

| ThreadX configuration | result | elapsed |
|---|---|---|
| trace_build | 3 of 3 | 39.3 s |
| disable_notify_callbacks | 3 of 3 | 38.2 s |
| default_build_coverage | 3 of 3 | 38.0 s |
| stack_checking | 3 of 3 | 27.3 s |
| stack_checking_rand_fill | 3 of 3 | 10.0 s |

All five SMP configurations reached 20 of 20 in 0 to 1 second. Every suite passed in full: ThreadX 96 of 96 and SMP 110 of 110 across five configurations each, FreeRTOS 3 of 3, with suite totals of 36 to 70 seconds per configuration.

**The new failure path fires, and only when it should.** With the handler's window made unreachable and the ceiling lowered to 5 seconds, the test stops after 6 seconds, prints the count it reached, and reports `ERROR #8` with the harness recording a failure rather than a pass. With the count raised past what the budget allows, a run that reaches two windows still passes — so falling short and reaching nothing stay distinct.

**Locally**, all five configurations reach 3 of 3 in 5 to 14 seconds, and both suites pass 96 of 96 and 110 of 110 run one test at a time.

**The `TX_NOT_INTERRUPTABLE` branch** is compile-checked in both copies using the configurations' own compile commands. No configuration in either suite builds it, so it is not covered by a normal run; `condition_count` is expected to be zero there, which is why the new failure is compiled out of that path.

## Known, and deliberately not addressed here

**`threadx_thread_delayed_suspension_test` has the same shape of hole.** Since #645 it skips its dependent check when its window is not reached, so a zero-window run there is also a pass that verified nothing. It has never fallen short in twenty configuration-runs — 4.06 seconds against a 120 second budget at worst — so there is no measured problem to fix, and it is left alone rather than changed on the strength of an argument by analogy.

**One unrelated intermittent turned up while measuring.** `threadx_smp_random_resume_suspend_exclusion_pt_test` failed with `ERROR #7` on a first attempt in `trace_build` and passed on retry, on a sixteen core machine running the suite one test at a time. It did not recur in any CI run, including one with `--repeat until-pass:1`, so it is recorded here rather than diagnosed.
