### PR TITLE
Ran the regression suites on dev, where the pull requests actually are

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -1,13 +1,24 @@
 name: regression_test
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Runs the ThreadX, SMP and FreeRTOS-compatibility regression suites.
+#
+# dev is included as well as master, for the same reason ports_arch_check.yml
+# names it: dev is the integration branch, so a check that runs only against
+# master gates nothing that anybody opens. Until now these suites ran on no
+# pull request that anybody actually raised, and the last dev run of any kind
+# was a manual workflow_dispatch.
+#
+# That run, on 2026-08-18, failed two tests: threadx_timer_simple_test in the
+# ThreadX suite and threadx_thread_priority_change in the SMP one. Both are
+# fixed -- the first by running the suites one test at a time (#643), the
+# second by #647 -- and both suites now pass all 1030 tests across all ten
+# build configurations. The suites were never the problem; the trigger was.
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
The ThreadX, SMP and FreeRTOS-compatibility regression suites trigger on `master` only, for both `push` and `pull_request`:

```yaml
on:
  push:
    branches: [ master ]
  pull_request:
    branches: [ master ]
```

`dev` is the integration branch, so **these suites have gated no pull request that anybody opened.** The last `dev` run of any kind was a manual `workflow_dispatch` on 18 August.

This is the same defect `ports_arch_check.yml` already carries a comment about — where it cost eight months of ports drifting from `ports_arch` unnoticed. `ci_cortex_m.yml` has it too, and is handled separately.

## Why the 18 August run failing is not a reason to leave this off

That run failed, which is exactly why it is worth checking *before* switching this on rather than after. Two tests, one per job:

| Job | Test | Symptom |
|---|---|---|
| `tx` | `threadx_timer_simple_test` | `ERROR #28`, 1 of 96 |
| `smp` | `threadx_thread_priority_change` | **Timeout**, 1 of 110 |

**Both were fixed two days later**, on 20 August:

- `#643` ran the suites one test at a time, which is what a timer test failing only under parallel load wants — `threadx_timer_simple_test` passes in 1.66 s in isolation.
- `#647` fixed `threadx_thread_priority_change` by name, so it stopped leaving core 0 to a finished thread.

So the red run describes a tree that no longer exists.

## Verified, not assumed

Both suites were re-run on this tree before this change was written:

| Suite | Configurations | Tests | Result |
|---|---|---|---|
| `tx` | 5 | 5 × 96 = **480** | all pass, 33.96–64.13 s per configuration |
| `smp` | 5 | 5 × 110 = **550** | all pass, 61.38–62.67 s per configuration |

**1030 of 1030 across ten configurations.** For scale: the 18 August run took 36m19s, of which a single test that has since been given a budget (`#644`, `#649`) accounted for **439 seconds**.

## Two decisions in here worth reviewing

**No `paths:` filter, deliberately.** The suites build the `linux` port, so a filter would have to enumerate what *cannot* affect them. The failure mode of getting that list wrong is a regression that merges because the filter excluded the file that caused it. If PR latency turns out to be a problem, the better lever is splitting `tx` (12m6s of the 36) from `smp`.

**The `deploy` job needs no new guard.** `regression_template.yml` already restricts `deploy_code_coverage` to `push` and `workflow_dispatch` (line 171), and restricts the coverage PR comment to pull requests from the repository itself (line 135). So neither GitHub Pages nor the PR comment fires for a pull request from a fork; on a PR the `deploy` job is a no-op pass-through.

## What this does not fix

Coverage is still collected from **one build configuration of five** — only `default_build_coverage` carries `-fprofile-arcs`, so the code selected by the other four configurations is compiled out of the instrumented build and is absent from the denominator rather than counted as uncovered. And the coverage steps have no `if: always()`, so a single failing test suppresses the report for the whole run. Both are separate changes; this one is the trigger only.