### PR TITLE
Kept the coverage publish on master, where the environment allows it

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -89,6 +89,20 @@ jobs:
   #     skip_deploy: true
   #     skip_coverage: true
   deploy:
+    # Publishing the coverage report stays on master. Adding dev to this
+    # workflow's triggers was meant to run the suites on the branch the pull
+    # requests target, not to change what gets published -- and the first
+    # push to dev after that change failed here with 'Branch "dev" is not
+    # allowed to deploy to github-pages due to environment protection rules',
+    # while all three suites passed. The github-pages environment restricts
+    # deployments to master, so the job was rejected before it ran.
+    #
+    # Guarding here rather than relaxing the environment rule, because the
+    # rule is doing its job: it is a deliberate answer to the question of
+    # which branch the published report describes. Moving that answer to dev
+    # is a separate decision, and it needs the environment setting changed
+    # as well as this line removed.
+    if: github.ref == 'refs/heads/master'
     permissions:
       contents: read
       issues: read


### PR DESCRIPTION
Follow-up to #652, fixing a side effect of it.

Running the regression suites on `dev` was meant to test the branch the pull requests target. It changed what gets *published* as well, which was not intended and does not work. The first push to `dev` after that merge (`977e14e7`, run `32745263374`) failed:

```
X Branch "dev" is not allowed to deploy to github-pages due to environment protection rules.
X The deployment was rejected or didn't satisfy other protection rules.
  deploy / deploy_code_coverage
```

**All three suites passed in that run** — `tx` ✓, `smp` ✓, `freertos` ✓. The only failure was the Pages deployment, rejected before it ran, because the `github-pages` environment restricts deployments to `master`.

## Why guard the job rather than relax the environment rule

The environment rule is doing its job. Which branch the published coverage report describes is a deliberate decision, and moving it from `master` to `dev` is worth making on purpose rather than inheriting as a side effect of a trigger fix. If that move is wanted, it needs the environment setting changed *as well as* this line removed — so it is a separate change with a separate conversation.

## Scope

Only the `deploy` job needed a guard. `tx`, `smp` and `freertos` all pass `skip_deploy: true`, and `regression_template.yml` already restricts `deploy_code_coverage` to `push` and `workflow_dispatch` — they showed as skipped in the failing run. The `deploy` job is the one that publishes, and it was the only one reaching the environment.

## Unrelated, but visible in the same run

Two things worth someone's attention, neither introduced here:

- **Node 20 deprecation warnings** on `actions/checkout@v4.2.2`, `actions/configure-pages@v5.0.0`, `actions/upload-artifact@v4.6.2`, `LouisBrunner/checks-action@v2.0.0` and `marocchino/sticky-pull-request-comment@v2.9.4`. They are being forced onto Node 24 already.
- **Suite runtime varies a great deal between runners.** The `tx` job took **4m38s** on #652's pull-request run and **22m5s** on the push run of the same commit — same 96 tests, five configurations, all passing both times. Per-configuration test time went from 26–29 s to 172–328 s. Worth knowing before anyone sizes PR latency from a single sample.