### PR TITLE
Published the coverage report instead of everything the run produced

### DIFF
--- a/.github/workflows/regression_template.yml
+++ b/.github/workflows/regression_template.yml
@@ -178,10 +178,37 @@ jobs:
       id-token: write
 
     steps:
+    # Selects the coverage artifacts by pattern rather than by name.
+    #
+    # This used to ask for ${{ steps.artifact.outputs.coverage_report }},
+    # which is set by the "Coverage Report name" step of run_tests -- a
+    # different job. The steps context does not cross jobs, so that
+    # expression evaluated to the empty string and the action fell back to
+    # its documented behaviour for an unspecified name: "No input name,
+    # artifact-ids or pattern filtered specified, downloading all
+    # artifacts". It pulled down four, the two coverage reports and the two
+    # test_reports bundles of JUnit XML, each into a directory named after
+    # the artifact -- so the published site carried the test reports as well
+    # as the coverage, under paths containing a run timestamp that changed
+    # on every publish.
+    #
+    # merge-multiple puts the contents of both coverage artifacts directly
+    # into coverage_report rather than under a directory named for each
+    # artifact. Each one holds a single directory named for its suite,
+    # ThreadX or SMP, renamed from default_build_coverage by the "Prepare
+    # Coverage GitHub Pages" step, so the merge yields exactly the two
+    # suite directories the deploy expects, and the artifact name -- with
+    # its timestamp -- stops appearing in the published path at all.
+    #
+    # The two artifacts also each carry a default_build_coverage.xml, and
+    # the merge means one overwrites the other. That file is consumed by
+    # CodeCoverageSummary back in run_tests and is not read here, so this is
+    # untidy rather than wrong.
     - uses: actions/download-artifact@v4.3.0
       if: ${{ inputs.skip_test }}
       with:
-        name: ${{ steps.artifact.outputs.coverage_report }}
+        pattern: coverage_report-*
+        merge-multiple: true
         path: ${{ inputs.cmake_path }}/coverage_report
 
     - name: Upload Code Coverage Pages
@@ -190,10 +217,16 @@ jobs:
       with:
         path: .
 
+    # The artifacts are named coverage_report-<epoch> by run_tests, so the
+    # bare name matched nothing: useGlob defaults to true in this action, and
+    # as a glob "coverage_report" matches only the literal string. The step
+    # has therefore been deleting nothing. It does not fail on a miss, which
+    # is why that went unnoticed; retention-days: 1 on the upload is what has
+    # actually been clearing these up.
     - name: Delete Duplicate Code Coverage Artifact
       uses: geekyeggo/delete-artifact@v5.1.0
       with:
-          name: coverage_report
+          name: coverage_report-*
 
     - name: Deploy GitHub Pages site
       id: deployment


### PR DESCRIPTION
`deploy_code_coverage` downloads the coverage artifacts by name:

```yaml
- uses: actions/download-artifact@v4.3.0
  with:
    name: ${{ steps.artifact.outputs.coverage_report }}
```

That output is set by the **"Coverage Report name"** step of `run_tests` — **a different job**. The `steps` context does not cross jobs, so the expression evaluates to the empty string and the action takes its documented path for an unspecified name. From a real run:

```
No input name, artifact-ids or pattern filtered specified, downloading all artifacts
Total of 4 artifact(s) downloaded
```

The four are the two coverage reports **and the two `test_reports` bundles of JUnit XML**, each extracted into a directory named after the artifact. The next step uploads all of it to Pages.

So the published site has been carrying the JUnit test reports alongside the coverage, one directory deeper than intended, under a path containing a run timestamp that changes on every publish. **Any link to a coverage report broke the next time one was published.**

## The fix

Select by pattern, and merge:

```yaml
    pattern: coverage_report-*
    merge-multiple: true
```

The pattern excludes the `test_reports` bundles. `merge-multiple` puts the contents of both coverage artifacts directly into `coverage_report` rather than under a directory named for each — and since each artifact holds exactly one directory named for its suite (renamed from `default_build_coverage` by *Prepare Coverage GitHub Pages*), the result is the two suite directories the deploy expects, with the timestamped artifact name gone from the published path.

## Verified on a runner, not reasoned about

`deploy_code_coverage` only runs on push to `master`, so this cannot be exercised by a PR. Rather than merge and hope, I ran an isolated workflow that uploads artifacts shaped like the real ones and downloads them both ways:

| | Result |
|---|---|
| **OLD** | `coverage_report/coverage_report-<epoch>-ThreadX/ThreadX/index.html`<br>`coverage_report/coverage_report-<epoch>-ThreadX/default_build_coverage.xml`<br>`coverage_report/coverage_report-<epoch>-SMP/SMP/index.html`<br>`coverage_report/coverage_report-<epoch>-SMP/default_build_coverage.xml`<br>`coverage_report/test_reports SMP/results.xml`<br>`coverage_report/test_reports ThreadX/results.xml` |
| **NEW** | `coverage_report/ThreadX/index.html`<br>`coverage_report/SMP/index.html`<br>`coverage_report/default_build_coverage.xml` |

`Total of 4 artifact(s) downloaded` becomes `Total of 2`.

Both artifacts carry a `default_build_coverage.xml`, so the merge means one overwrites the other — visible in that run too. It is consumed by `CodeCoverageSummary` back in `run_tests` and is not read here, so it is untidy rather than wrong; there is a comment saying so.

## The delete step, same place and same cause

```yaml
- name: Delete Duplicate Code Coverage Artifact
  uses: geekyeggo/delete-artifact@v5.1.0
  with:
      name: coverage_report
```

The artifacts are named `coverage_report-<epoch>`. `useGlob` defaults to `true` in this action, and as a glob `coverage_report` matches only the literal string — so this has been deleting nothing, without failing. `retention-days: 1` on the upload is what has actually been clearing them up. Now `coverage_report-*`.

## Why this is worth doing now rather than later

Node 20 is removed from the runners on **16 September 2026**, so the artifact actions have to move within about three weeks. A `download-artifact` upgrade cannot be meaningfully validated while the step is exercising the download-everything path instead of the one it is supposed to take — and v5's breaking change is specifically about *single-artifact* downloads, the case this workflow only enters once the selection is correct. Fixing the selection first means the upgrade is tested against the real path.

## Not in scope

The published coverage HTML embeds runner absolute paths in its filenames (`index._home_runner_work_threadx_threadx_common_smp_src_tx_thread_delete.c.html`). That comes from how `gcovr` is invoked in `test/*/cmake/coverage.sh`, not from this workflow, and it belongs in a separate change.