### PR TITLE
Allowed the Linux toolchain file to accept a compiler override

### DIFF
--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -1,8 +1,25 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-set(CMAKE_C_COMPILER    gcc)
-set(CMAKE_CXX_COMPILER  g++)
+# Let the compiler be chosen on the command line or from the environment, for example
+# -DCMAKE_C_COMPILER=gcc-14 or CC=gcc-14. CMake reads a toolchain file before it consults
+# CC and CXX, so setting these unconditionally would quietly override both and leave no
+# way to build with anything but the distribution's default gcc.
+if(NOT DEFINED CMAKE_C_COMPILER)
+  if(DEFINED ENV{CC})
+    set(CMAKE_C_COMPILER $ENV{CC})
+  else()
+    set(CMAKE_C_COMPILER gcc)
+  endif()
+endif()
+
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+  if(DEFINED ENV{CXX})
+    set(CMAKE_CXX_COMPILER $ENV{CXX})
+  else()
+    set(CMAKE_CXX_COMPILER g++)
+  endif()
+endif()
 set(AS                  as)
 set(AR                  ar)
 set(OBJCOPY             objcopy)


### PR DESCRIPTION
## Problem

`cmake/linux.cmake` set the compilers unconditionally:

```cmake
set(CMAKE_C_COMPILER    gcc)
set(CMAKE_CXX_COMPILER  g++)
```

CMake reads a toolchain file *before* it consults `CC`/`CXX`, and a plain `set()` in a toolchain file also takes precedence over `-DCMAKE_C_COMPILER`. So neither of the two usual ways to choose a compiler had any effect — the tree could only be built with whatever `/usr/bin/gcc` happened to point at.

That matters because `AGENTS.md` names GCC 14 as the project's default compiler on Linux, while distributions ship an older `gcc` as the system default for some time yet. On Ubuntu 24.04, for instance, `gcc` is 13.3 and the `gcc` metapackage `Depends: gcc-13`, so the only ways to build with GCC 14 were to edit this file locally or to repoint the machine's system-wide default with `update-alternatives` — the latter being fragile, since a later upgrade of the `gcc`/`g++`/`cpp` metapackages can silently restore the symlinks.

## Change

Both variables now fall back to `gcc`/`g++` only when nothing else has been specified.

The binutils variables in this file are deliberately left alone — they are unused on the Linux target, so guarding them would be unrelated churn. The same pattern would apply to the cross-compilation toolchain files under `cmake/` if that is wanted; happy to follow up separately.

## Verification

All on Ubuntu 24.04, `-m32`, `disable_notify_callbacks_build`:

| Selection method | Compiler used | Result |
|---|---|---|
| Default (`./run.sh build …`, nothing set) | gcc 13.3.0 | 96/96 pass |
| `-DCMAKE_C_COMPILER=gcc-14` | gcc 14.2.0 | 96/96 pass |
| `CC=gcc-14` | gcc 14.2.0 | resolves correctly |

The default path is unchanged — same compiler, same 96/96 — so this is additive.

Separately, the whole tree was built and tested under GCC 14.2.0 across all five build configurations (`default_build_coverage`, `disable_notify_callbacks_build`, `stack_checking_build`, `stack_checking_rand_fill_build`, `trace_build`), 97/97 each with zero compiler diagnostics. GCC 14 promotes several C warnings to hard errors (`-Wimplicit-function-declaration`, `-Wint-conversion`, `-Wincompatible-pointer-types`), and with `-Werror` enabled in this tree that was the main risk — it is clean. `gcovr 7.0` also reads `gcov-14` output without trouble, so the coverage target is unaffected.