### PR TITLE
Reconfigured the build when the requested compiler changes

### DIFF
--- a/scripts/cmake_bootstrap.sh
+++ b/scripts/cmake_bootstrap.sh
@@ -31,8 +31,32 @@ function validate() {
     help
 }
 
+# CMake records the compiler it detected inside the build directory and keeps using it on
+# every later configure. Changing CC would otherwise be ignored without a word: the build
+# reports success while still using the compiler the directory was first configured with,
+# so anyone verifying a change against a second compiler would be reading stale results.
+# Only the C compiler is consulted, because these test trees declare LANGUAGES C.
+function compiler_changed() {
+    local build=$1
+    local recorded requested
+
+    [ -d "build/$build" ] || return 1
+
+    recorded=$(sed -n 's/^set(CMAKE_C_COMPILER "\(.*\)")$/\1/p' build/$build/CMakeFiles/*/CMakeCCompiler.cmake 2>/dev/null | head -1)
+    [ -n "$recorded" ] || return 1
+
+    requested=$(command -v "${CC:-gcc}" 2>/dev/null)
+    [ -n "$requested" ] || return 1
+
+    [ "$recorded" != "$requested" ]
+}
+
 function generate() {
     build=$1
+    if compiler_changed $build; then
+        echo "Compiler changed since build/$build was configured. Reconfiguring from scratch."
+        rm -rf build/$build
+    fi
     cmake -Bbuild/$build -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=$(dirname $(realpath $0))/../cmake/linux.cmake -DCMAKE_BUILD_TYPE=$build .
 }
 
@@ -41,6 +65,10 @@ function build() {
 }
 
 function build_libs() {
+    if compiler_changed libs; then
+        echo "Compiler changed since build/libs was configured. Reconfiguring from scratch."
+        rm -rf build/libs
+    fi
     cmake -Bbuild/libs -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=$(dirname $(realpath $0))/../cmake/linux.cmake libs
     cmake --build build/libs
 }


### PR DESCRIPTION
Follow-up to #656.

## Problem

CMake records the compiler it detected inside the build directory and keeps using it on every later configure. Now that `cmake/linux.cmake` honours `CC`, that turns a compiler switch into a silent no-op:

```console
$ ./run.sh build disable_notify_callbacks_build          # configures with gcc 13
$ CC=gcc-14 ./run.sh build disable_notify_callbacks_build
...
ninja: no work to do.
$ echo $?
0
```

It reports success, and the build is still gcc 13. Someone checking a change against a second compiler would be reading stale results while being told the build succeeded — the failure mode is a wrong answer rather than an error, which is what makes it worth fixing rather than documenting.

## Change

`generate()` compares the compiler recorded in the build directory against the one currently requested, and reconfigures from scratch only when they differ. `build_libs()` gets the same treatment.

The comparison uses the path in the form CMake records it — the unresolved path as given — so `/usr/bin/gcc` matches `command -v gcc` rather than the versioned target its symlink resolves to. Comparing resolved paths would have produced a spurious wipe on every single run.

Only the C compiler is consulted: both trees that use this script (`test/tx/cmake` and `test/smp/cmake`, which symlink to it) declare `LANGUAGES C`, so no CXX compiler is ever detected.

## Verification

Compiler selection, `test/tx/cmake`:

| Scenario | Reconfigured? | Compiler used | Incremental preserved |
|---|---|---|---|
| Fresh, default | no | gcc 13.3.0 | — |
| Repeat, default | no | gcc 13.3.0 | yes (`no work to do`) |
| Switch to `CC=gcc-14` | yes | gcc 14.2.0 | n/a |
| Repeat, same `CC` | no | gcc 14.2.0 | yes (`no work to do`) |
| Switch back to default | yes | gcc 13.3.0 | n/a |

Suites, via the canonical `./run.sh build` + `./run.sh test` path:

- `test/tx/cmake` — 96/96 with gcc 13.3.0, and 96/96 with `CC=gcc-14` after the automatic reconfigure.
- `test/smp/cmake` — 110/110 with gcc 13.3.0, and 110/110 with `CC=gcc-14`.

One note on the SMP tree: `threadx_smp_time_slice_test` fails intermittently under a bare `ctest` invocation but passes under the `--repeat until-pass:2` policy this script already applies, on both compilers and with and without this change. It is timing-sensitive and unrelated to this patch.