### PR TITLE
Matched gcov to the compiler that produced the coverage data

### DIFF
--- a/test/smp/cmake/coverage.sh
+++ b/test/smp/cmake/coverage.sh
@@ -16,5 +16,31 @@ set -e
 cd $(dirname $0)
 threadx_smp=$(realpath ../../../common_smp/src)
 mkdir -p coverage_report/$1
-gcovr --object-directory=build/$1/threadx_smp/CMakeFiles/threadx_smp.dir/$threadx_smp -r build/$1 -f ../../../common_smp/src --xml-pretty --output coverage_report/$1.xml
-gcovr --object-directory=build/$1/threadx_smp/CMakeFiles/threadx_smp.dir/$threadx_smp -r build/$1 -f ../../../common_smp/src --html --html-details --output coverage_report/$1/index.html
+
+# gcov reads a data format tied to the compiler that produced it, so gcov has to match
+# the gcc that built the objects. Since cmake/linux.cmake began honouring CC, taking
+# whatever gcov happens to be first on PATH is no longer safe: building with gcc-14 and
+# reading with gcov-13 gives "version 'B42*', prefer 'B33*'" from gcov, and gcovr turns
+# that into "GCOV returncode was 3" and exits 64. The tests pass and then the coverage
+# step fails with a Python traceback, which reads like a coverage bug rather than a
+# toolchain mismatch.
+#
+# So derive gcov from CC rather than asking the caller to remember both. GCOV still
+# overrides, for a toolchain that does not follow the gcc/gcov naming.
+: "${CC:=gcc}"
+if [ -z "${GCOV:-}" ]; then
+    cc_base=$(basename "$CC")
+    case "$cc_base" in
+        gcc*) GCOV="gcov${cc_base#gcc}" ;;
+        *)    GCOV="gcov" ;;
+    esac
+fi
+
+if ! command -v "$GCOV" >/dev/null 2>&1; then
+    echo "coverage.sh: '$GCOV' not found, derived from CC='$CC'." >&2
+    echo "Install it, or set GCOV to the gcov matching that compiler." >&2
+    exit 1
+fi
+
+gcovr --gcov-executable "$GCOV" --object-directory=build/$1/threadx_smp/CMakeFiles/threadx_smp.dir/$threadx_smp -r build/$1 -f ../../../common_smp/src --xml-pretty --output coverage_report/$1.xml
+gcovr --gcov-executable "$GCOV" --object-directory=build/$1/threadx_smp/CMakeFiles/threadx_smp.dir/$threadx_smp -r build/$1 -f ../../../common_smp/src --html --html-details --output coverage_report/$1/index.html

--- a/test/tx/cmake/coverage.sh
+++ b/test/tx/cmake/coverage.sh
@@ -15,5 +15,31 @@ set -e
 
 cd $(dirname $0)
 mkdir -p coverage_report/$1
-gcovr --object-directory=build/$1/threadx/CMakeFiles/threadx.dir/common/src -r build/$1 -f ../../../common/src --xml-pretty --output coverage_report/$1.xml
-gcovr --object-directory=build/$1/threadx/CMakeFiles/threadx.dir/common/src -r build/$1 -f ../../../common/src --html --html-details --output coverage_report/$1/index.html
+
+# gcov reads a data format tied to the compiler that produced it, so gcov has to match
+# the gcc that built the objects. Since cmake/linux.cmake began honouring CC, taking
+# whatever gcov happens to be first on PATH is no longer safe: building with gcc-14 and
+# reading with gcov-13 gives "version 'B42*', prefer 'B33*'" from gcov, and gcovr turns
+# that into "GCOV returncode was 3" and exits 64. The tests pass and then the coverage
+# step fails with a Python traceback, which reads like a coverage bug rather than a
+# toolchain mismatch.
+#
+# So derive gcov from CC rather than asking the caller to remember both. GCOV still
+# overrides, for a toolchain that does not follow the gcc/gcov naming.
+: "${CC:=gcc}"
+if [ -z "${GCOV:-}" ]; then
+    cc_base=$(basename "$CC")
+    case "$cc_base" in
+        gcc*) GCOV="gcov${cc_base#gcc}" ;;
+        *)    GCOV="gcov" ;;
+    esac
+fi
+
+if ! command -v "$GCOV" >/dev/null 2>&1; then
+    echo "coverage.sh: '$GCOV' not found, derived from CC='$CC'." >&2
+    echo "Install it, or set GCOV to the gcov matching that compiler." >&2
+    exit 1
+fi
+
+gcovr --gcov-executable "$GCOV" --object-directory=build/$1/threadx/CMakeFiles/threadx.dir/common/src -r build/$1 -f ../../../common/src --xml-pretty --output coverage_report/$1.xml
+gcovr --gcov-executable "$GCOV" --object-directory=build/$1/threadx/CMakeFiles/threadx.dir/common/src -r build/$1 -f ../../../common/src --html --html-details --output coverage_report/$1/index.html


### PR DESCRIPTION
Companion to #656 and #657. Neither is wrong; together they open a hole that this closes.

`gcov` reads a data format tied to the compiler that produced it. `coverage.sh` took whatever `gcov` was first on `PATH`, which was fine while the compiler was *also* whatever was first on `PATH`. #656 made `cmake/linux.cmake` honour `CC`, and #657 made a compiler switch actually reconfigure the build — so that assumption no longer holds, and **the first person to use the new capability would have hit this.**

Measured on `dev` with both merged:

```
$ CC=gcc-14 ./run.sh build default_build_coverage     # succeeds
$ ./coverage.sh default_build_coverage
RuntimeError: GCOV returncode was 3.
EXIT=64
```

`gcov` says why, if asked directly:

```
tx_block_allocate.c.gcno:version 'B42*', prefer 'B33*'
```

The part that would have cost someone an afternoon is *where* it surfaces: the tests all pass, then the coverage step dies with a Python traceback, which reads like a `gcovr` bug rather than a toolchain mismatch.

## The change

`gcov` is derived from `CC` instead of found on `PATH`, so the caller sets one variable rather than remembering two. `GCOV` still overrides, for a toolchain that does not follow the `gcc`/`gcov` naming, and a derived `gcov` that does not exist is reported as such rather than surfacing as a traceback.

Applied to both `test/tx/cmake/coverage.sh` and `test/smp/cmake/coverage.sh`.

## Verified, both suites

| Invocation | Before | After |
|---|---|---|
| `CC=gcc-14` | **exit 64**, traceback | exit 0 — 177 files, 1527/3827 lines |
| `CC` unset (what CI does) | exit 0 | exit 0 — 177 files, 1527/3827 lines, unchanged |
| `CC=gcc-99` | n/a | exit 1, naming `gcov-99` and `CC`, not a traceback |
| `GCOV=gcov-14` with `CC=gcc-99` | n/a | exit 0 — the override still wins |

**CI is unaffected**: nothing in the workflows sets `CC`, so the default path is byte-for-byte the behaviour it had before.

## One deliberate non-fix

Reading a gcc-14 tree with the default gcc-13 `gcov` still fails with exit 64. That pairing *is* wrong, and producing a number from mismatched coverage data would be worse than refusing. Only the case where `CC` is stated is made to work.