### PR TITLE
Pinned every action to a commit SHA, and moved them off Node 20

### DIFF
--- a/.github/workflows/ci_cortex_m.yml
+++ b/.github/workflows/ci_cortex_m.yml
@@ -54,14 +54,18 @@ jobs:
       GCC_TARGET: arm-none-eabi
 
     steps:
+    # Actions are pinned to a commit SHA, with the version in the trailing
+    # comment. A tag can be moved; a SHA cannot, so this is what makes "which
+    # code ran in CI" answerable from the repository. Dependabot moves these
+    # pins and rewrites the comment with them -- see .github/dependabot.yml.
     - name: Check out the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: true
 
     - name: Cache the Arm GNU toolchain
       id: cache-arm-gcc
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: toolchain
         key: arm-gnu-toolchain-${{ env.GCC_VERSION }}-x86_64-${{ env.GCC_TARGET }}

--- a/.github/workflows/clang_check.yml
+++ b/.github/workflows/clang_check.yml
@@ -27,12 +27,16 @@ jobs:
       ATFE_VERSION: 22.1.0
 
     steps:
+    # Actions are pinned to a commit SHA, with the version in the trailing
+    # comment. A tag can be moved; a SHA cannot, so this is what makes "which
+    # code ran in CI" answerable from the repository. Dependabot moves these
+    # pins and rewrites the comment with them -- see .github/dependabot.yml.
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Cache Arm Toolchain for Embedded
       id: cache-atfe
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: atfe
         key: atfe-${{ env.ATFE_VERSION }}-linux-x86_64

--- a/.github/workflows/ports_arch_check.yml
+++ b/.github/workflows/ports_arch_check.yml
@@ -35,8 +35,12 @@ jobs:
     # supplied: token" and the check never evaluated anything. The default
     # GITHUB_TOKEN is enough to check out a public repository, and the
     # repository has no submodules.
+    # Actions are pinned to a commit SHA, with the version in the trailing
+    # comment. A tag can be moved; a SHA cannot, so this is what makes "which
+    # code ran in CI" answerable from the repository. Dependabot moves these
+    # pins and rewrites the comment with them -- see .github/dependabot.yml.
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Check the port trees: the generated ports must be reproducible from
     # ports_arch, and no port header may be left unbalanced or carrying code
@@ -60,7 +64,7 @@ jobs:
     # GITHUB_TOKEN is enough to check out a public repository, and the
     # repository has no submodules.
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Regenerate the A profile ports and fail if anything changed, which means
     # a generated port was edited directly instead of ports_arch.

--- a/.github/workflows/regression_template.yml
+++ b/.github/workflows/regression_template.yml
@@ -62,8 +62,12 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    # Actions are pinned to a commit SHA, with the version in the trailing
+    # comment. A tag can be moved; a SHA cannot, so this is what makes "which
+    # code ran in CI" answerable from the repository. Dependabot moves these
+    # pins and rewrites the comment with them -- see .github/dependabot.yml.
     - name: Check out the repository
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: true
 
@@ -84,7 +88,7 @@ jobs:
       run: ${{ inputs.test_script }}
 
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2.11.0
+      uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
       if: always()
       with:
         check_name: Test Results ${{ inputs.result_affix }}
@@ -93,7 +97,7 @@ jobs:
 
     - name: Upload Test Results
       if: success() || failure()
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: test_reports ${{ inputs.result_affix }}
         path: |
@@ -102,7 +106,7 @@ jobs:
           ${{ inputs.cmake_path }}/build/**/regression/output_files/*.bin
 
     - name: Configure GitHub Pages
-      uses: actions/configure-pages@v5.0.0
+      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
     # The coverage steps below run even when a test failed. cmake_bootstrap.sh
     # now produces the report in that case, and the run whose behaviour changed
@@ -113,7 +117,7 @@ jobs:
     # ! opens a YAML tag, and the expression will not parse without it.
     - name: Generate Code Coverage Results Summary
       if: ${{ !cancelled() && (!inputs.skip_coverage) }}
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
       with:
         filename: ${{ inputs.cmake_path }}/coverage_report/${{ inputs.coverage_name }}.xml
         format: markdown
@@ -129,7 +133,7 @@ jobs:
 
     - name: Create CheckRun for Code Coverage
       if: ${{ !cancelled() && ((github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event.pull_request.head.repo.full_name == github.repository)) && (!inputs.skip_coverage) }}
-      uses: LouisBrunner/checks-action@v2.0.0
+      uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         name: Code Coverage ${{ inputs.result_affix }}
@@ -140,7 +144,7 @@ jobs:
 
     - name: Add Code Coverage PR Comment
       if: ${{ !cancelled() && ((github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == github.repository)) && (!inputs.skip_coverage) }}
-      uses: marocchino/sticky-pull-request-comment@v2.9.4
+      uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
       with:
         header: Code Coverage ${{ inputs.result_affix }}
         path: code-coverage-results.md
@@ -160,7 +164,7 @@ jobs:
       run: echo "coverage_report=coverage_report-$(date +%s)" >> $GITHUB_OUTPUT
 
     - name: Upload Code Coverage Artifacts
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ !cancelled() && (inputs.skip_deploy && !inputs.skip_coverage) }}
       with:
           name: ${{ steps.artifact.outputs.coverage_report }}
@@ -168,7 +172,7 @@ jobs:
           retention-days: 1
 
     - name: Upload Code Coverage Pages
-      uses: actions/upload-pages-artifact@v3.0.1
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       if: ${{ !cancelled() && (!inputs.skip_deploy && !inputs.skip_coverage) }}
       with:
         path: ${{ inputs.cmake_path }}/coverage_report/${{ inputs.coverage_name }}
@@ -211,7 +215,7 @@ jobs:
     # the merge means one overwrites the other. That file is consumed by
     # CodeCoverageSummary back in run_tests and is not read here, so this is
     # untidy rather than wrong.
-    - uses: actions/download-artifact@v4.3.0
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       if: ${{ inputs.skip_test }}
       with:
         pattern: coverage_report-*
@@ -219,7 +223,7 @@ jobs:
         path: ${{ inputs.cmake_path }}/coverage_report
 
     - name: Upload Code Coverage Pages
-      uses: actions/upload-pages-artifact@v3.0.1
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       if: ${{ inputs.skip_test }}
       with:
         path: .
@@ -231,13 +235,13 @@ jobs:
     # is why that went unnoticed; retention-days: 1 on the upload is what has
     # actually been clearing these up.
     - name: Delete Duplicate Code Coverage Artifact
-      uses: geekyeggo/delete-artifact@v5.1.0
+      uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
       with:
           name: coverage_report-*
 
     - name: Deploy GitHub Pages site
       id: deployment
-      uses: actions/deploy-pages@v4.0.5
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
     - name: Write Code Coverage Report URL
       run: >-


### PR DESCRIPTION
**Node 20 is removed from the GitHub runners on 16 September 2026.** Every run in this repository currently carries the deprecation warning, naming `actions/checkout`, `actions/configure-pages`, `actions/upload-artifact`, `LouisBrunner/checks-action` and `marocchino/sticky-pull-request-comment`. After that date those actions stop working rather than warning — so this is a deadline, not housekeeping.

## Two problems, one change

**Referencing was inconsistent and unpinned.** `actions/checkout` appeared as both `@v4` and `@v4.2.2` in the same repository, and nothing was pinned to a commit. Every reference is now a 40-character SHA with the version in a trailing comment:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

A tag can be repointed at any commit; a SHA cannot. That is what makes *"which code ran in our CI"* answerable from the repository rather than from whatever the tag meant at the time — worth having on its own for a project building an SBOM story.

**Nothing has ever reported that an action moved**, so the versions had drifted by as much as four majors:

| Action | Was | Now |
|---|---|---|
| `actions/download-artifact` | v4.3.0 | **v8.0.1** |
| `actions/checkout` | v4 / v4.2.2 | **v7.0.1** |
| `actions/upload-artifact` | v4.6.2 | **v7.0.1** |
| `actions/cache` | v4 | **v6.1.0** |
| `actions/upload-pages-artifact` | v3.0.1 | **v5.0.0** |
| `actions/configure-pages` | v5.0.0 | v6.0.0 |
| `actions/deploy-pages` | v4.0.5 | v5.0.0 |
| `LouisBrunner/checks-action` | v2.0.0 | v3.1.0 |
| `marocchino/sticky-pull-request-comment` | v2.9.4 | v3.0.5 |
| `geekyeggo/delete-artifact` | v5.1.0 | v6.0.0 |
| `EnricoMi/publish-unit-test-result-action` | v2.11.0 | v2.24.0 |
| `irongut/CodeCoverageSummary` | v1.3.0 | v1.3.0 — already current, pinned not moved |

19 references across 4 files. All of the new versions run on `node24` (or are composite).

## Compatibility checked, not assumed

Against each new `action.yml`, for every input this repository actually passes:

- **checkout** — `submodules` unchanged. **cache** — `path`, `key` unchanged.
- **upload-artifact** — `name`, `path`, `retention-days` unchanged.
- **download-artifact** — `pattern`, `merge-multiple`, `path` unchanged.
- **configure-pages** — takes no input here, and none became required.
- **deploy-pages** — still exposes `page_url`, which the job reads via `steps.deployment.outputs.page_url`.
- **upload-pages-artifact** — `path` unchanged.
- **checks-action** — `token`, `name`, `conclusion`, `output`, `output_text_description_file` all survive v2 → v3.
- **sticky-comment** — `header` and `path` survive v2 → v3, and the new `GITHUB_TOKEN` input **defaults to `${{ github.token }}`**, which is what v2 used implicitly. No change needed.
- **delete-artifact** — `name` survives v5 → v6, and **`useGlob` still defaults to `true`**, so the `coverage_report-*` glob from #655 still matches.

## The artifact pair, verified on a runner

They move together, as they must. Before this commit I ran the round trip on a real runner — `upload-artifact` v7 → `download-artifact` v8, through the `pattern` + `merge-multiple` selection #655 introduced:

```
Found 4 artifact(s)
Filtering artifacts by pattern 'coverage_report-*'
Total of 2 artifact(s) downloaded

cov/SMP/index.html
cov/ThreadX/index.html
cov/default_build_coverage.xml
```

Exactly the tree the deploy expects. That is the one four-major jump in here and the only place with documented breaking changes, so it seemed worth more than a reading of the release notes.

## Two behaviour changes worth knowing

- **`download-artifact` v8 adds a `digest-mismatch` input defaulting to `error`.** A corrupted artifact now fails the job rather than passing through. That is the right default, but it is a change.
- **`upload-artifact` v6 and above require a runner of at least 2.327.1.** The hosted runners satisfy this; a self-hosted runner would need checking — relevant if the FVP work ever moves to one.

## What comes next

This PR is deliberately the catch-up only. A `.github/dependabot.yml` follows separately, so that the pins are moved by something that opens one reviewable PR per change instead of drifting for another three years. Doing it the other way round would have had Dependabot open a wall of PRs against the backlog above.