### PR TITLE
Bumped gcovr off the 4.1 pin it had been held on since 2018

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,7 +78,24 @@ retry sudo "${TIMEOUT[@]}" apt-get "${APT_OPTIONS[@]}" install -y \
     software-properties-common || exit 1
 
 retry "${TIMEOUT[@]}" python3 -m pip install --retries 3 --timeout 30 --upgrade pip || exit 1
-retry "${TIMEOUT[@]}" pip3 install --retries 3 --timeout 30 gcovr==4.1 || exit 1
+# gcovr was pinned to 4.1, released in 2018. That version cannot do what merging
+# the coverage of several build configurations needs: it has no --json and no
+# --add-tracefile, both of which arrived later. The pin is exact rather than
+# floating so the coverage percentage stays comparable between runs -- the
+# denominator is a property of the tool as much as of the tree -- and it is moved
+# by hand, because it lives in a shell script that Dependabot cannot parse.
+#
+# Measured before bumping, on the default_build_coverage tree of test/tx, over
+# the same gcda with the same gcov, varying only the gcovr version: 4.1, 7.0,
+# 8.3 and 8.6 all report lines-valid 3827 across 177 files and branches-valid
+# 1994. The denominator does not move with the tool, so this bump moves no
+# number and any movement in a later run belongs to a later change.
+#
+# The numerator does move, but not because of gcovr: tx_thread_system_resume.c
+# line 529 is executed on some runs of the suite and not others, so the same
+# tree reports 3826 or 3827 covered lines with every test passing either way.
+# That is a property of the suite, not of this pin.
+retry "${TIMEOUT[@]}" pip3 install --retries 3 --timeout 30 gcovr==8.6 || exit 1
 
 # Upgrade cmake to the latest version.
 retry "${TIMEOUT[@]}" pip install --retries 3 --timeout 30 --upgrade cmake || exit 1


### PR DESCRIPTION
`scripts/install.sh` pinned `gcovr==4.1`, released in 2018. That version has neither `--json` nor `--add-tracefile`, which is exactly how the five build configurations would be merged into a single coverage report — so the pin is a prerequisite for the rest of the coverage work, not just staleness.

This moves it to **8.6**, the current release. The pin stays exact, so a coverage percentage remains comparable between runs, and it stays hand-moved: it lives in a shell script that no Dependabot ecosystem can parse. The new comment in `install.sh` says so, since #662 might otherwise imply this is now automated.

**Nothing else is in this pull request on purpose** — the number movement it might cause should not be confused with one caused by a later change.

## It moves no number

Measured on the `default_build_coverage` tree of `test/tx`, over the same `.gcda` with the same `gcov`, varying only the gcovr version:

| gcovr | lines-valid | branches-valid | files |
|---|---|---|---|
| 4.1 | 3827 | 1994 | 177 |
| 7.0 | 3827 | 1994 | 177 |
| 8.3 | 3827 | 1994 | 177 |
| 8.6 | 3827 | 1994 | 177 |

The denominator does not move with the tool. The plan behind this work expected 3822 → 3827 across the bump; **that figure does not reproduce** — not under gcc-13, not under gcc-14, and not with `--object-directory` dropped. The only variant that changes the count is dropping the `-f ../../../common/src` filter, which collapses the report to zero files.

## Two findings worth more than the bump

**The coverage numerator is not deterministic.** On an identical tree with an identical compiler, three consecutive runs of the full suite — all 96 tests passing every time — reported:

| run | lines | branches | uncovered |
|---|---|---|---|
| 1 | 3826/3827 | 1992/1994 | `tx_thread_system_resume.c:529` |
| 2 | 3827/3827 | 1993/1994 | none |
| 3 | 3827/3827 | 1993/1994 | none |

That line is `_tx_thread_system_return();` — the "preemption is needed, return to the system" path of `_tx_thread_system_resume` — and it takes its guarding branch with it. It has been characterised as never executed by the suite. It is executed on *some* runs and not others. Two consequences: a coverage floor set at the observed maximum would flake, and the real fix is a test that takes that path deliberately rather than by timing.

**`--xml-pretty` and `--object-directory` still work on 8.6, but only as deprecated aliases** for `--cobertura-pretty` and `--gcov-object-directory`. Nothing to change here — worth knowing for whoever removes `--object-directory`, which measurably does nothing anyway.

## Verification

Reading gcc-13 output — the compiler the runners actually use, since `install.sh` installs plain `gcc` and nothing sets `CC` — gcovr 8.6 runs the existing `test/tx/cmake/coverage.sh` unchanged end to end: Cobertura XML plus 181 HTML files, same 177 classes, exit 0. 96/96 tests passed.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>