### PR TITLE
ports: add ARMv7-A SMP Linux build scripts(A5,A7,A9)

### DIFF
--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
@@ -37,7 +37,7 @@ case "${TOOLCHAIN}" in
 esac
 
 rm -f tx.a
-"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -x assembler-with-cpp tx_initialize_low_level.s
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 tx_initialize_low_level.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_context_restore.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_context_save.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_control.S

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
@@ -1,259 +1,281 @@
 #!/bin/sh
 set -e
+
+# this script builds the ThreadX library for the Cortex-A5 SMP port using
+# GNU toolchain or llvm/clang toolchain (defaults to GNU).
+: "${TOOLCHAIN:=gnu}"
+
+case "${TOOLCHAIN}" in
+    gnu)
+        CC="arm-none-eabi-gcc"
+        AR="arm-none-eabi-ar"
+        TARGET_FLAGS=""
+        ;;
+    atfe)
+        CC="${ATFE_CLANG:-clang}"
+        AR="llvm-ar"
+        TARGET_FLAGS="--target=arm-none-eabi"
+        ;;
+    *)
+        echo "Unknown TOOLCHAIN: ${TOOLCHAIN}" >&2
+        exit 1
+        ;;
+esac
+
 rm -f tx.a
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -x assembler-with-cpp tx_initialize_low_level.s
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_context_restore.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_context_save.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_control.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_disable.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_restore.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_irq_nesting_end.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_irq_nesting_start.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_schedule.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_core_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_core_preempt.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_current_state_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_current_thread_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_initialize_wait.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_low_level_initialize.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_protect.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_time_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_unprotect.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_stack_build.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_system_return.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_vectored_context_save.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_timer_interrupt.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
-arm-none-eabi-ar -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
-arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o
-arm-none-eabi-ar -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
-arm-none-eabi-ar -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
-arm-none-eabi-ar -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
-arm-none-eabi-ar -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
-arm-none-eabi-ar -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
-arm-none-eabi-ar -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
-arm-none-eabi-ar -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
-arm-none-eabi-ar -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
-arm-none-eabi-ar -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
-arm-none-eabi-ar -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
-arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o
-arm-none-eabi-ar -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
-arm-none-eabi-ar -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
-arm-none-eabi-ar -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
-arm-none-eabi-ar -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
-arm-none-eabi-ar -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
-arm-none-eabi-ar -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
-arm-none-eabi-ar -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
-arm-none-eabi-ar -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
-arm-none-eabi-ar -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
-arm-none-eabi-ar -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
-arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o
-arm-none-eabi-ar -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
-arm-none-eabi-ar -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
-arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o
-arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o
-arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o
-arm-none-eabi-ar -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
-arm-none-eabi-ar -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
-arm-none-eabi-ar -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
-arm-none-eabi-ar -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
-arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o
-arm-none-eabi-ar -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
-arm-none-eabi-ar -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
-arm-none-eabi-ar -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -x assembler-with-cpp tx_initialize_low_level.s
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_context_restore.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_context_save.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_control.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_disable.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_restore.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_irq_nesting_end.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_irq_nesting_start.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_schedule.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_core_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_core_preempt.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_current_state_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_current_thread_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_initialize_wait.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_low_level_initialize.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_protect.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_time_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_unprotect.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_stack_build.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_system_return.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_thread_vectored_context_save.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 ../src/tx_timer_interrupt.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
+"${AR}" -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
+"${AR}" -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o
+"${AR}" -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
+"${AR}" -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
+"${AR}" -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
+"${AR}" -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
+"${AR}" -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
+"${AR}" -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
+"${AR}" -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
+"${AR}" -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
+"${AR}" -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
+"${AR}" -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
+"${AR}" -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o
+"${AR}" -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
+"${AR}" -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
+"${AR}" -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
+"${AR}" -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
+"${AR}" -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
+"${AR}" -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
+"${AR}" -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
+"${AR}" -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
+"${AR}" -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
+"${AR}" -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
+"${AR}" -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o
+"${AR}" -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
+"${AR}" -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
+"${AR}" -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o
+"${AR}" -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o
+"${AR}" -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o
+"${AR}" -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
+"${AR}" -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
+"${AR}" -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
+"${AR}" -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
+"${AR}" -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o
+"${AR}" -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
+"${AR}" -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
+"${AR}" -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
+"${AR}" -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
+"${AR}" -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
+"${AR}" -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
+"${AR}" -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+##############################################################################
+# Copyright (c) 2026 Eclipse ThreadX contributors
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+##############################################################################
+
 set -e
 cd "$(dirname "$0")"
 

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+cd "$(dirname "$0")"
 
 # this script builds the ThreadX library for the Cortex-A5 SMP port using
 # GNU toolchain or llvm/clang toolchain (defaults to GNU).
@@ -13,7 +14,10 @@ case "${TOOLCHAIN}" in
         ;;
     atfe)
         CC="${ATFE_CLANG:-clang}"
-        AR="llvm-ar"
+        case "${CC}" in
+            */*) AR="$(dirname "${CC}")/llvm-ar" ;;
+            *)   AR="llvm-ar" ;;
+        esac
         TARGET_FLAGS="--target=arm-none-eabi"
         ;;
     *)

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx.sh
@@ -1,0 +1,259 @@
+#!/bin/sh
+set -e
+rm -f tx.a
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -x assembler-with-cpp tx_initialize_low_level.s
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_context_restore.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_context_save.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_control.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_disable.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_interrupt_restore.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_irq_nesting_end.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_irq_nesting_start.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_schedule.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_core_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_core_preempt.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_current_state_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_current_thread_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_initialize_wait.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_low_level_initialize.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_protect.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_time_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_smp_unprotect.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_stack_build.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_system_return.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_thread_vectored_context_save.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 ../src/tx_timer_interrupt.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
+arm-none-eabi-ar -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
+arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o
+arm-none-eabi-ar -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
+arm-none-eabi-ar -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
+arm-none-eabi-ar -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
+arm-none-eabi-ar -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
+arm-none-eabi-ar -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
+arm-none-eabi-ar -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
+arm-none-eabi-ar -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
+arm-none-eabi-ar -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
+arm-none-eabi-ar -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
+arm-none-eabi-ar -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
+arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o
+arm-none-eabi-ar -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
+arm-none-eabi-ar -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
+arm-none-eabi-ar -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
+arm-none-eabi-ar -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
+arm-none-eabi-ar -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
+arm-none-eabi-ar -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
+arm-none-eabi-ar -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
+arm-none-eabi-ar -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
+arm-none-eabi-ar -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
+arm-none-eabi-ar -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
+arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o
+arm-none-eabi-ar -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
+arm-none-eabi-ar -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
+arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o
+arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o
+arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o
+arm-none-eabi-ar -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
+arm-none-eabi-ar -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
+arm-none-eabi-ar -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
+arm-none-eabi-ar -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
+arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o
+arm-none-eabi-ar -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
+arm-none-eabi-ar -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
+arm-none-eabi-ar -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,14 +1,42 @@
 #!/bin/sh
 set -e
-arm-none-eabi-gcc -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a5 sample_threadx.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 startup.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_GIC.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_SCU.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_Mutexes.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_PrivateTimer.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a5 v7.S
-arm-none-eabi-gcc -g -mcpu=cortex-a5 \
-    -T sample_threadx.ld --specs=nosys.specs -e Vectors \
+
+# this script builds the ThreadX sample image for the Cortex-A5 SMP port using
+# GNU toolchain or llvm/clang toolchain (defaults to GNU).
+: "${TOOLCHAIN:=gnu}"
+case "${TOOLCHAIN}" in
+    gnu)
+        CC="arm-none-eabi-gcc"
+        TARGET_FLAGS="" # GNU and Clang use different driver syntax for selecting the program's
+        # entry-point symbol.
+        ENTRY_FLAG="-e Vectors"
+        # Bare-metal C libraries require syscall support. GNU uses newlib's nosys stubs
+        # while ATFE requires a semihost library.
+        SYSCALL_LIB="--specs=nosys.specs"
+        ;;
+    atfe)
+        CC="${ATFE_CLANG:-clang}"
+        TARGET_FLAGS="--target=arm-none-eabi"
+        ENTRY_FLAG="-Wl,--entry=Vectors"
+        SYSCALL_LIB="-lsemihost"
+        ;;
+    *)
+        echo "Unknown TOOLCHAIN: ${TOOLCHAIN}" >&2
+        exit 1
+        ;;
+esac
+
+"${CC}" ${TARGET_FLAGS} -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a5 sample_threadx.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 startup.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_GIC.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_SCU.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_Mutexes.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_PrivateTimer.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 v7.S
+"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a5 \
+    -T sample_threadx.ld \
+    ${ENTRY_FLAG} \
+    ${SYSCALL_LIB} \
     -o sample_threadx.out \
     MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o \
     sample_threadx.o startup.o v7.o tx.a \

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
@@ -30,16 +30,17 @@ esac
 
 "${CC}" ${TARGET_FLAGS} -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a5 sample_threadx.c
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 startup.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_GIC.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_SCU.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_Mutexes.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 MP_PrivateTimer.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a5 v7.S
-"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a5 \
+"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a5 -nostartfiles \
     -T sample_threadx.ld \
     ${ENTRY_FLAG} \
     ${SYSCALL_LIB} \
     -o sample_threadx.out \
     MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o \
-    sample_threadx.o startup.o v7.o tx.a \
+    sample_threadx.o startup.o crt0.o v7.o tx.a \
     -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
@@ -7,4 +7,9 @@ arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_SCU.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_Mutexes.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_PrivateTimer.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-a5 v7.S
-arm-none-eabi-gcc -T sample_threadx.ld -e Vectors -o sample_threadx.out MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o sample_threadx.o startup.o v7.o tx.a -Wl,-M > sample_threadx.map
+arm-none-eabi-gcc -g -mcpu=cortex-a5 \
+    -T sample_threadx.ld --specs=nosys.specs -e Vectors \
+    -o sample_threadx.out \
+    MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o \
+    sample_threadx.o startup.o v7.o tx.a \
+    -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+##############################################################################
+# Copyright (c) 2026 Eclipse ThreadX contributors
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+##############################################################################
+
 set -e
 cd "$(dirname "$0")"
 

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+arm-none-eabi-gcc -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a5 sample_threadx.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 startup.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_GIC.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_SCU.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_Mutexes.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 MP_PrivateTimer.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a5 v7.S
+arm-none-eabi-gcc -T sample_threadx.ld -e Vectors -o sample_threadx.out MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o sample_threadx.o startup.o v7.o tx.a -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+cd "$(dirname "$0")"
 
 # this script builds the ThreadX sample image for the Cortex-A5 SMP port using
 # GNU toolchain or llvm/clang toolchain (defaults to GNU).
@@ -7,7 +8,8 @@ set -e
 case "${TOOLCHAIN}" in
     gnu)
         CC="arm-none-eabi-gcc"
-        TARGET_FLAGS="" # GNU and Clang use different driver syntax for selecting the program's
+        TARGET_FLAGS=""
+        # GNU and Clang use different driver syntax for selecting the program's
         # entry-point symbol.
         ENTRY_FLAG="-e Vectors"
         # Bare-metal C libraries require syscall support. GNU uses newlib's nosys stubs

--- a/ports_smp/cortex_a5_smp/gnu/example_build/crt0.S
+++ b/ports_smp/cortex_a5_smp/gnu/example_build/crt0.S
@@ -1,0 +1,101 @@
+
+    .syntax unified
+#if defined(THUMB_MODE)
+    .thumb
+#else
+    .arm
+#endif
+
+/* .text is used instead of .section .text so it works with arm-aout too.  */
+    .text
+    .align  0
+
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global _mainCRTStartup
+_mainCRTStartup:
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global _start
+_start:
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global start
+start:
+
+/* Start by setting up a stack */
+    /*  Set up the stack pointer to a fixed value */
+    ldr r3, .LC0
+    mov     sp, r3
+    /* Setup a default stack-limit in case the code has been
+       compiled with "-mapcs-stack-check".  Hard-wiring this value
+       is not ideal, since there is currently no support for
+       checking that the heap and stack have not collided, or that
+       this default 64k is enough for the program being executed.
+       However, it ensures that this simple crt0 world will not
+       immediately cause an overflow event:  */
+    sub sl, sp, #64 << 10   /* Still assumes 256bytes below sl */
+    mov     a2, #0          /* Second arg: fill value */
+    mov fp, a2          /* Null frame pointer */
+    mov r7, a2          /* Null frame pointer for Thumb */
+
+    ldr a1, .LC1        /* First arg: start of memory block */
+    ldr a3, .LC2
+    sub a3, a3, a1      /* Third arg: length of block */
+
+
+
+        bl      memset
+    mov r0, #0      /*  no arguments  */
+    mov r1, #0      /*  no argv either */
+#ifdef __USES_INITFINI__
+    /* Some arm/elf targets use the .init and .fini sections
+       to create constructors and destructors, and for these
+       targets we need to call the _init function and arrange
+       for _fini to be called at program exit.  */
+    mov r4, r0
+    mov r5, r1
+/*        ldr     r0, .Lfini */
+        bl      atexit
+/*        bl      init */
+    mov r0, r4
+    mov r1, r5
+#endif
+        bl      main
+
+        bl      exit         /* Should not return.  */
+
+
+    /* For Thumb, constants must be after the code since only
+       positive offsets are supported for PC relative addresses.  */
+
+    .align 0
+.LC0:
+.LC1:
+    .word   __bss_start__
+.LC2:
+    .word   __bss_end__
+/*
+#ifdef __USES_INITFINI__
+.Lfini:
+    .word   _fini
+#endif  */
+    /* Return ...  */
+    bx  lr
+
+    .global  _fini
+    .type    _fini,function
+_fini:
+    BX      lr                                  // Return to caller
+
+/*  Workspace for Angel calls.  */
+    .data
+/*  Data returned by monitor SWI.  */
+.global __stack_base__
+HeapBase:   .word   0
+HeapLimit:  .word   0
+__stack_base__: .word   0
+StackLimit: .word   0

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+##############################################################################
+# Copyright (c) 2026 Eclipse ThreadX contributors
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+##############################################################################
+
 set -e
 cd "$(dirname "$0")"
 

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+cd "$(dirname "$0")"
 
 # this script builds the ThreadX library for the Cortex-A7 SMP port using
 # GNU toolchain or llvm/clang toolchain (defaults to GNU).
@@ -13,7 +14,10 @@ case "${TOOLCHAIN}" in
         ;;
     atfe)
         CC="${ATFE_CLANG:-clang}"
-        AR="llvm-ar"
+        case "${CC}" in
+            */*) AR="$(dirname "${CC}")/llvm-ar" ;;
+            *)   AR="llvm-ar" ;;
+        esac
         TARGET_FLAGS="--target=arm-none-eabi"
         ;;
     *)

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
@@ -1,0 +1,259 @@
+#!/bin/sh
+set -e
+rm -f tx.a
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 tx_initialize_low_level.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_stack_build.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_schedule.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_system_return.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_context_save.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_context_restore.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_control.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_timer_interrupt.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_disable.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_restore.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_irq_nesting_end.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_irq_nesting_start.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_vectored_context_save.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_core_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_core_preempt.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_current_state_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_current_thread_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_initialize_wait.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_low_level_initialize.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_protect.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_time_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_unprotect.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
+arm-none-eabi-ar -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
+arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o 
+arm-none-eabi-ar -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
+arm-none-eabi-ar -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
+arm-none-eabi-ar -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
+arm-none-eabi-ar -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
+arm-none-eabi-ar -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
+arm-none-eabi-ar -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
+arm-none-eabi-ar -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
+arm-none-eabi-ar -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
+arm-none-eabi-ar -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
+arm-none-eabi-ar -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
+arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o 
+arm-none-eabi-ar -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
+arm-none-eabi-ar -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
+arm-none-eabi-ar -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
+arm-none-eabi-ar -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
+arm-none-eabi-ar -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
+arm-none-eabi-ar -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
+arm-none-eabi-ar -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
+arm-none-eabi-ar -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
+arm-none-eabi-ar -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
+arm-none-eabi-ar -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
+arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o 
+arm-none-eabi-ar -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
+arm-none-eabi-ar -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
+arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o 
+arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o 
+arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o 
+arm-none-eabi-ar -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
+arm-none-eabi-ar -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
+arm-none-eabi-ar -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
+arm-none-eabi-ar -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
+arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o 
+arm-none-eabi-ar -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
+arm-none-eabi-ar -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
+arm-none-eabi-ar -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
@@ -22,7 +22,7 @@ arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_initialize_wait.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_low_level_initialize.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_protect.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_time_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_unprotect.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -x assembler-with-cpp ../src/tx_thread_smp_unprotect.s
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
@@ -217,7 +217,7 @@ arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ..
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
 arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
 arm-none-eabi-ar -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
-arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o 
+arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o
 arm-none-eabi-ar -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
 arm-none-eabi-ar -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
 arm-none-eabi-ar -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
@@ -228,7 +228,7 @@ arm-none-eabi-ar -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o t
 arm-none-eabi-ar -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
 arm-none-eabi-ar -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
 arm-none-eabi-ar -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
-arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o 
+arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o
 arm-none-eabi-ar -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
 arm-none-eabi-ar -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
 arm-none-eabi-ar -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
@@ -239,17 +239,17 @@ arm-none-eabi-ar -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_t
 arm-none-eabi-ar -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
 arm-none-eabi-ar -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
 arm-none-eabi-ar -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
-arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o 
+arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o
 arm-none-eabi-ar -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
 arm-none-eabi-ar -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
-arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o 
-arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o 
-arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o 
+arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o
+arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o
+arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o
 arm-none-eabi-ar -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
 arm-none-eabi-ar -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
 arm-none-eabi-ar -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
 arm-none-eabi-ar -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
-arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o 
+arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o
 arm-none-eabi-ar -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
 arm-none-eabi-ar -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
 arm-none-eabi-ar -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
@@ -1,259 +1,281 @@
 #!/bin/sh
 set -e
+
+# this script builds the ThreadX library for the Cortex-A7 SMP port using
+# GNU toolchain or llvm/clang toolchain (defaults to GNU).
+: "${TOOLCHAIN:=gnu}"
+
+case "${TOOLCHAIN}" in
+    gnu)
+        CC="arm-none-eabi-gcc"
+        AR="arm-none-eabi-ar"
+        TARGET_FLAGS=""
+        ;;
+    atfe)
+        CC="${ATFE_CLANG:-clang}"
+        AR="llvm-ar"
+        TARGET_FLAGS="--target=arm-none-eabi"
+        ;;
+    *)
+        echo "Unknown TOOLCHAIN: ${TOOLCHAIN}" >&2
+        exit 1
+        ;;
+esac
+
 rm -f tx.a
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 tx_initialize_low_level.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_stack_build.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_schedule.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_system_return.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_context_save.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_context_restore.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_control.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_timer_interrupt.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_disable.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_restore.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_irq_nesting_end.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_irq_nesting_start.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_vectored_context_save.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_core_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_core_preempt.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_current_state_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_current_thread_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_initialize_wait.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_low_level_initialize.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_protect.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_time_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -x assembler-with-cpp ../src/tx_thread_smp_unprotect.s
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
-arm-none-eabi-ar -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
-arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o
-arm-none-eabi-ar -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
-arm-none-eabi-ar -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
-arm-none-eabi-ar -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
-arm-none-eabi-ar -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
-arm-none-eabi-ar -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
-arm-none-eabi-ar -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
-arm-none-eabi-ar -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
-arm-none-eabi-ar -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
-arm-none-eabi-ar -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
-arm-none-eabi-ar -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
-arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o
-arm-none-eabi-ar -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
-arm-none-eabi-ar -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
-arm-none-eabi-ar -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
-arm-none-eabi-ar -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
-arm-none-eabi-ar -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
-arm-none-eabi-ar -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
-arm-none-eabi-ar -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
-arm-none-eabi-ar -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
-arm-none-eabi-ar -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
-arm-none-eabi-ar -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
-arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o
-arm-none-eabi-ar -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
-arm-none-eabi-ar -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
-arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o
-arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o
-arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o
-arm-none-eabi-ar -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
-arm-none-eabi-ar -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
-arm-none-eabi-ar -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
-arm-none-eabi-ar -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
-arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o
-arm-none-eabi-ar -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
-arm-none-eabi-ar -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
-arm-none-eabi-ar -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 tx_initialize_low_level.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_stack_build.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_schedule.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_system_return.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_context_save.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_context_restore.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_control.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_timer_interrupt.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_disable.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_interrupt_restore.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_irq_nesting_end.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_irq_nesting_start.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_vectored_context_save.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_core_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_core_preempt.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_current_state_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_current_thread_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_initialize_wait.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_low_level_initialize.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_protect.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_time_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -x assembler-with-cpp ../src/tx_thread_smp_unprotect.s
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
+"${AR}" -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
+"${AR}" -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o
+"${AR}" -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
+"${AR}" -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
+"${AR}" -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
+"${AR}" -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
+"${AR}" -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
+"${AR}" -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
+"${AR}" -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
+"${AR}" -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
+"${AR}" -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
+"${AR}" -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
+"${AR}" -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o
+"${AR}" -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
+"${AR}" -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
+"${AR}" -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
+"${AR}" -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
+"${AR}" -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
+"${AR}" -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
+"${AR}" -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
+"${AR}" -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
+"${AR}" -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
+"${AR}" -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
+"${AR}" -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o
+"${AR}" -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
+"${AR}" -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
+"${AR}" -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o
+"${AR}" -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o
+"${AR}" -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o
+"${AR}" -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
+"${AR}" -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
+"${AR}" -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
+"${AR}" -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
+"${AR}" -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o
+"${AR}" -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
+"${AR}" -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
+"${AR}" -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
+"${AR}" -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
+"${AR}" -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
+"${AR}" -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
+"${AR}" -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx.sh
@@ -58,7 +58,7 @@ rm -f tx.a
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_low_level_initialize.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_protect.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_time_get.S
-"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -x assembler-with-cpp ../src/tx_thread_smp_unprotect.s
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 ../src/tx_thread_smp_unprotect.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,8 +1,42 @@
 #!/bin/sh
 set -e
-arm-none-eabi-gcc -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a7 sample_threadx.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 startup.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 MP_GIC.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 MP_Mutexes.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a7 v7.S
-arm-none-eabi-gcc -T sample_threadx.ld --specs=nosys.specs -e Vectors -o sample_threadx.out MP_GIC.o MP_Mutexes.o sample_threadx.o startup.o v7.o tx.a -Wl,-M > sample_threadx.map
+
+# this script builds the ThreadX sample image for the Cortex-A7 SMP port using
+# GNU toolchain or llvm/clang toolchain (defaults to GNU).
+: "${TOOLCHAIN:=gnu}"
+case "${TOOLCHAIN}" in
+    gnu)
+        CC="arm-none-eabi-gcc"
+        TARGET_FLAGS=""
+        # GNU and Clang use different driver syntax for selecting the program's
+        # entry-point symbol.
+        ENTRY_FLAG="-e Vectors"
+        # Bare-metal C libraries require syscall support. GNU uses newlib's nosys stubs
+        # while ATFE requires a semihost library.
+        SYSCALL_LIB="--specs=nosys.specs"
+        ;;
+    atfe)
+        CC="${ATFE_CLANG:-clang}"
+        TARGET_FLAGS="--target=arm-none-eabi"
+        ENTRY_FLAG="-Wl,--entry=Vectors"
+        SYSCALL_LIB="-lsemihost"
+        ;;
+    *)
+        echo "Unknown TOOLCHAIN: ${TOOLCHAIN}" >&2
+        exit 1
+        ;;
+esac
+
+"${CC}" ${TARGET_FLAGS} -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a7 sample_threadx.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 startup.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 MP_GIC.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 MP_Mutexes.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 v7.S
+"${CC}" ${TARGET_FLAGS} \
+    -T sample_threadx.ld \
+    ${SYSCALL_LIB} \
+    ${ENTRY_FLAG} \
+    -o sample_threadx.out \
+    MP_GIC.o MP_Mutexes.o \
+    sample_threadx.o startup.o v7.o tx.a \
+    -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
@@ -30,14 +30,15 @@ esac
 
 "${CC}" ${TARGET_FLAGS} -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a7 sample_threadx.c
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 startup.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 MP_GIC.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 MP_Mutexes.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 v7.S
-"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a7 \
+"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a7 -nostartfiles \
     -T sample_threadx.ld \
     ${SYSCALL_LIB} \
     ${ENTRY_FLAG} \
     -o sample_threadx.out \
     MP_GIC.o MP_Mutexes.o \
-    sample_threadx.o startup.o v7.o tx.a \
+    sample_threadx.o startup.o crt0.o v7.o tx.a \
     -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+##############################################################################
+# Copyright (c) 2026 Eclipse ThreadX contributors
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+##############################################################################
+
 set -e
 cd "$(dirname "$0")"
 

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+cd "$(dirname "$0")"
 
 # this script builds the ThreadX sample image for the Cortex-A7 SMP port using
 # GNU toolchain or llvm/clang toolchain (defaults to GNU).
@@ -32,7 +33,7 @@ esac
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 MP_GIC.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 MP_Mutexes.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a7 v7.S
-"${CC}" ${TARGET_FLAGS} \
+"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a7 \
     -T sample_threadx.ld \
     ${SYSCALL_LIB} \
     ${ENTRY_FLAG} \

--- a/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+arm-none-eabi-gcc -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a7 sample_threadx.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 startup.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 MP_GIC.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 MP_Mutexes.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a7 v7.S
+arm-none-eabi-gcc -T sample_threadx.ld --specs=nosys.specs -e Vectors -o sample_threadx.out MP_GIC.o MP_Mutexes.o sample_threadx.o startup.o v7.o tx.a -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a7_smp/gnu/example_build/crt0.S
+++ b/ports_smp/cortex_a7_smp/gnu/example_build/crt0.S
@@ -1,0 +1,101 @@
+
+    .syntax unified
+#if defined(THUMB_MODE)
+    .thumb
+#else
+    .arm
+#endif
+
+/* .text is used instead of .section .text so it works with arm-aout too.  */
+    .text
+    .align  0
+
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global _mainCRTStartup
+_mainCRTStartup:
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global _start
+_start:
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global start
+start:
+
+/* Start by setting up a stack */
+    /*  Set up the stack pointer to a fixed value */
+    ldr r3, .LC0
+    mov     sp, r3
+    /* Setup a default stack-limit in case the code has been
+       compiled with "-mapcs-stack-check".  Hard-wiring this value
+       is not ideal, since there is currently no support for
+       checking that the heap and stack have not collided, or that
+       this default 64k is enough for the program being executed.
+       However, it ensures that this simple crt0 world will not
+       immediately cause an overflow event:  */
+    sub sl, sp, #64 << 10   /* Still assumes 256bytes below sl */
+    mov     a2, #0          /* Second arg: fill value */
+    mov fp, a2          /* Null frame pointer */
+    mov r7, a2          /* Null frame pointer for Thumb */
+
+    ldr a1, .LC1        /* First arg: start of memory block */
+    ldr a3, .LC2
+    sub a3, a3, a1      /* Third arg: length of block */
+
+
+
+        bl      memset
+    mov r0, #0      /*  no arguments  */
+    mov r1, #0      /*  no argv either */
+#ifdef __USES_INITFINI__
+    /* Some arm/elf targets use the .init and .fini sections
+       to create constructors and destructors, and for these
+       targets we need to call the _init function and arrange
+       for _fini to be called at program exit.  */
+    mov r4, r0
+    mov r5, r1
+/*        ldr     r0, .Lfini */
+        bl      atexit
+/*        bl      init */
+    mov r0, r4
+    mov r1, r5
+#endif
+        bl      main
+
+        bl      exit         /* Should not return.  */
+
+
+    /* For Thumb, constants must be after the code since only
+       positive offsets are supported for PC relative addresses.  */
+
+    .align 0
+.LC0:
+.LC1:
+    .word   __bss_start__
+.LC2:
+    .word   __bss_end__
+/*
+#ifdef __USES_INITFINI__
+.Lfini:
+    .word   _fini
+#endif  */
+    /* Return ...  */
+    bx  lr
+
+    .global  _fini
+    .type    _fini,function
+_fini:
+    BX      lr                                  // Return to caller
+
+/*  Workspace for Angel calls.  */
+    .data
+/*  Data returned by monitor SWI.  */
+.global __stack_base__
+HeapBase:   .word   0
+HeapLimit:  .word   0
+__stack_base__: .word   0
+StackLimit: .word   0

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+##############################################################################
+# Copyright (c) 2026 Eclipse ThreadX contributors
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+##############################################################################
+
 set -e
 cd "$(dirname "$0")"
 

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+cd "$(dirname "$0")"
 
 # this script builds the ThreadX library for the Cortex-A9 SMP port using
 # GNU toolchain or llvm/clang toolchain (defaults to GNU).
@@ -13,7 +14,10 @@ case "${TOOLCHAIN}" in
         ;;
     atfe)
         CC="${ATFE_CLANG:-clang}"
-        AR="llvm-ar"
+        case "${CC}" in
+            */*) AR="$(dirname "${CC}")/llvm-ar" ;;
+            *)   AR="llvm-ar" ;;
+        esac
         TARGET_FLAGS="--target=arm-none-eabi"
         ;;
     *)

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
@@ -1,259 +1,281 @@
 #!/bin/sh
 set -e
+
+# this script builds the ThreadX library for the Cortex-A9 SMP port using
+# GNU toolchain or llvm/clang toolchain (defaults to GNU).
+: "${TOOLCHAIN:=gnu}"
+
+case "${TOOLCHAIN}" in
+    gnu)
+        CC="arm-none-eabi-gcc"
+        AR="arm-none-eabi-ar"
+        TARGET_FLAGS=""
+        ;;
+    atfe)
+        CC="${ATFE_CLANG:-clang}"
+        AR="llvm-ar"
+        TARGET_FLAGS="--target=arm-none-eabi"
+        ;;
+    *)
+        echo "Unknown TOOLCHAIN: ${TOOLCHAIN}" >&2
+        exit 1
+        ;;
+esac
+
 rm -f tx.a
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 tx_initialize_low_level.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_context_restore.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_context_save.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_control.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_disable.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_restore.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_irq_nesting_end.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_irq_nesting_start.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_schedule.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_core_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_core_preempt.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_current_state_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_current_thread_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_initialize_wait.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_low_level_initialize.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_protect.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_time_get.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_unprotect.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_stack_build.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_system_return.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_vectored_context_save.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_timer_interrupt.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
-arm-none-eabi-ar -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
-arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o 
-arm-none-eabi-ar -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
-arm-none-eabi-ar -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
-arm-none-eabi-ar -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
-arm-none-eabi-ar -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
-arm-none-eabi-ar -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
-arm-none-eabi-ar -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
-arm-none-eabi-ar -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
-arm-none-eabi-ar -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
-arm-none-eabi-ar -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
-arm-none-eabi-ar -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
-arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o 
-arm-none-eabi-ar -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
-arm-none-eabi-ar -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
-arm-none-eabi-ar -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
-arm-none-eabi-ar -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
-arm-none-eabi-ar -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
-arm-none-eabi-ar -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
-arm-none-eabi-ar -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
-arm-none-eabi-ar -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
-arm-none-eabi-ar -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
-arm-none-eabi-ar -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
-arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o 
-arm-none-eabi-ar -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
-arm-none-eabi-ar -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
-arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o 
-arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o 
-arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o 
-arm-none-eabi-ar -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
-arm-none-eabi-ar -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
-arm-none-eabi-ar -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
-arm-none-eabi-ar -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
-arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o 
-arm-none-eabi-ar -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
-arm-none-eabi-ar -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
-arm-none-eabi-ar -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
-arm-none-eabi-ar -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 tx_initialize_low_level.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_context_restore.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_context_save.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_control.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_disable.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_restore.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_irq_nesting_end.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_irq_nesting_start.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_schedule.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_core_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_core_preempt.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_current_state_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_current_thread_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_initialize_wait.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_low_level_initialize.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_protect.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_time_get.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_unprotect.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_stack_build.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_system_return.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_thread_vectored_context_save.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 ../src/tx_timer_interrupt.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
+"${AR}" -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
+"${AR}" -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o
+"${AR}" -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
+"${AR}" -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
+"${AR}" -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
+"${AR}" -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
+"${AR}" -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
+"${AR}" -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
+"${AR}" -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
+"${AR}" -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
+"${AR}" -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
+"${AR}" -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
+"${AR}" -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o
+"${AR}" -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
+"${AR}" -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
+"${AR}" -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
+"${AR}" -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
+"${AR}" -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
+"${AR}" -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
+"${AR}" -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
+"${AR}" -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
+"${AR}" -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
+"${AR}" -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
+"${AR}" -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o
+"${AR}" -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
+"${AR}" -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
+"${AR}" -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o
+"${AR}" -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o
+"${AR}" -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o
+"${AR}" -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
+"${AR}" -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
+"${AR}" -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
+"${AR}" -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
+"${AR}" -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o
+"${AR}" -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
+"${AR}" -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
+"${AR}" -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
+"${AR}" -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
+"${AR}" -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
+"${AR}" -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
+"${AR}" -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx.sh
@@ -1,0 +1,259 @@
+#!/bin/sh
+set -e
+rm -f tx.a
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 tx_initialize_low_level.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_context_restore.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_context_save.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_control.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_disable.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_interrupt_restore.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_irq_nesting_end.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_irq_nesting_start.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_schedule.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_core_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_core_preempt.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_current_state_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_current_thread_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_initialize_wait.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_low_level_initialize.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_protect.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_time_get.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_smp_unprotect.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_stack_build.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_system_return.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_thread_vectored_context_save.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 ../src/tx_timer_interrupt.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_block_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_pool_search.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_byte_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_event_flags_set_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_high_level.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_enter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_initialize_kernel_setup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_mutex_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_flush.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_front_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_receive.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_queue_send_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_ceiling_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_cleanup.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_semaphore_put_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_entry_exit_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_identify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_preemption_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_relinquish.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_reset.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_shell_entry.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_sleep.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_analyze.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_handler.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_stack_error_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_preempt_check.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_system_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_terminate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_time_slice_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_timeout.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_wait_abort.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_time_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_expiration_process.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_performance_system_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_system_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_thread_entry.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_enable.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_disable.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_interrupt_control.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_enter_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_isr_exit_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_register.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_object_unregister.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_user_event_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_buffer_full_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_filter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_trace_event_unfilter.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_block_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_allocate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_pool_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_byte_release.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_event_flags_set_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_mutex_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_flush.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_front_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_receive.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_queue_send_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_ceiling_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_prioritize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_semaphore_put_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_entry_exit_notify.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_preemption_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_priority_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_relinquish.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_reset.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_resume.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_suspend.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_terminate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_time_slice_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_thread_wait_abort.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_activate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_change.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_create.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_deactivate.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_delete.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/txe_timer_info_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_current_state_set.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_debug_entry_insert.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_high_level_initialize.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_rebalance_execute_list.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_core_exclude_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_timer_smp_core_exclude_get.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 -I../../../../common_smp/inc -I../inc ../../../../common_smp/src/tx_thread_smp_utilities.c
+arm-none-eabi-ar -r tx.a tx_thread_stack_build.o tx_thread_schedule.o tx_thread_system_return.o tx_thread_context_save.o tx_thread_context_restore.o tx_timer_interrupt.o tx_thread_interrupt_control.o
+arm-none-eabi-ar -r tx.a tx_initialize_low_level.o tx_thread_interrupt_disable.o 
+arm-none-eabi-ar -r tx.a tx_thread_interrupt_restore.o tx_thread_irq_nesting_end.o tx_thread_irq_nesting_start.o
+arm-none-eabi-ar -r tx.a tx_block_allocate.o tx_block_pool_cleanup.o tx_block_pool_create.o tx_block_pool_delete.o tx_block_pool_info_get.o
+arm-none-eabi-ar -r tx.a tx_block_pool_initialize.o tx_block_pool_performance_info_get.o tx_block_pool_performance_system_info_get.o tx_block_pool_prioritize.o
+arm-none-eabi-ar -r tx.a tx_block_release.o tx_byte_allocate.o tx_byte_pool_cleanup.o tx_byte_pool_create.o tx_byte_pool_delete.o tx_byte_pool_info_get.o
+arm-none-eabi-ar -r tx.a tx_byte_pool_initialize.o tx_byte_pool_performance_info_get.o tx_byte_pool_performance_system_info_get.o tx_byte_pool_prioritize.o
+arm-none-eabi-ar -r tx.a tx_byte_pool_search.o tx_byte_release.o tx_event_flags_cleanup.o tx_event_flags_create.o tx_event_flags_delete.o tx_event_flags_get.o
+arm-none-eabi-ar -r tx.a tx_event_flags_info_get.o tx_event_flags_initialize.o tx_event_flags_performance_info_get.o tx_event_flags_performance_system_info_get.o
+arm-none-eabi-ar -r tx.a tx_event_flags_set.o tx_event_flags_set_notify.o tx_initialize_high_level.o tx_initialize_kernel_enter.o tx_initialize_kernel_setup.o
+arm-none-eabi-ar -r tx.a tx_mutex_cleanup.o tx_mutex_create.o tx_mutex_delete.o tx_mutex_get.o tx_mutex_info_get.o tx_mutex_initialize.o tx_mutex_performance_info_get.o
+arm-none-eabi-ar -r tx.a tx_mutex_performance_system_info_get.o tx_mutex_prioritize.o tx_mutex_priority_change.o tx_mutex_put.o tx_queue_cleanup.o tx_queue_create.o
+arm-none-eabi-ar -r tx.a tx_queue_delete.o tx_queue_flush.o tx_queue_front_send.o tx_queue_info_get.o tx_queue_initialize.o tx_queue_performance_info_get.o 
+arm-none-eabi-ar -r tx.a tx_queue_performance_system_info_get.o tx_queue_prioritize.o tx_queue_receive.o tx_queue_send.o tx_queue_send_notify.o tx_semaphore_ceiling_put.o
+arm-none-eabi-ar -r tx.a tx_semaphore_cleanup.o tx_semaphore_create.o tx_semaphore_delete.o tx_semaphore_get.o tx_semaphore_info_get.o tx_semaphore_initialize.o
+arm-none-eabi-ar -r tx.a tx_semaphore_performance_info_get.o tx_semaphore_performance_system_info_get.o tx_semaphore_prioritize.o tx_semaphore_put.o tx_semaphore_put_notify.o
+arm-none-eabi-ar -r tx.a tx_thread_create.o tx_thread_delete.o tx_thread_entry_exit_notify.o tx_thread_identify.o tx_thread_info_get.o tx_thread_initialize.o
+arm-none-eabi-ar -r tx.a tx_thread_performance_info_get.o tx_thread_performance_system_info_get.o tx_thread_preemption_change.o tx_thread_priority_change.o tx_thread_relinquish.o
+arm-none-eabi-ar -r tx.a tx_thread_reset.o tx_thread_resume.o tx_thread_shell_entry.o tx_thread_sleep.o tx_thread_stack_analyze.o tx_thread_stack_error_handler.o
+arm-none-eabi-ar -r tx.a tx_thread_stack_error_notify.o tx_thread_suspend.o tx_thread_system_preempt_check.o tx_thread_system_resume.o tx_thread_system_suspend.o
+arm-none-eabi-ar -r tx.a tx_thread_terminate.o tx_thread_time_slice.o tx_thread_time_slice_change.o tx_thread_timeout.o tx_thread_wait_abort.o tx_time_get.o
+arm-none-eabi-ar -r tx.a tx_time_set.o tx_timer_activate.o tx_timer_change.o tx_timer_create.o tx_timer_deactivate.o tx_timer_delete.o tx_timer_expiration_process.o
+arm-none-eabi-ar -r tx.a tx_timer_info_get.o tx_timer_initialize.o tx_timer_performance_info_get.o tx_timer_performance_system_info_get.o tx_timer_system_activate.o
+arm-none-eabi-ar -r tx.a tx_timer_system_deactivate.o tx_timer_thread_entry.o tx_trace_enable.o tx_trace_disable.o tx_trace_initialize.o tx_trace_interrupt_control.o 
+arm-none-eabi-ar -r tx.a tx_trace_isr_enter_insert.o tx_trace_isr_exit_insert.o tx_trace_object_register.o tx_trace_object_unregister.o tx_trace_user_event_insert.o
+arm-none-eabi-ar -r tx.a tx_trace_buffer_full_notify.o tx_trace_event_filter.o tx_trace_event_unfilter.o
+arm-none-eabi-ar -r tx.a txe_block_allocate.o txe_block_pool_create.o txe_block_pool_delete.o txe_block_pool_info_get.o txe_block_pool_prioritize.o txe_block_release.o 
+arm-none-eabi-ar -r tx.a txe_byte_allocate.o txe_byte_pool_create.o txe_byte_pool_delete.o txe_byte_pool_info_get.o txe_byte_pool_prioritize.o txe_byte_release.o 
+arm-none-eabi-ar -r tx.a txe_event_flags_create.o txe_event_flags_delete.o txe_event_flags_get.o txe_event_flags_info_get.o txe_event_flags_set.o 
+arm-none-eabi-ar -r tx.a txe_event_flags_set_notify.o txe_mutex_create.o txe_mutex_delete.o txe_mutex_get.o txe_mutex_info_get.o txe_mutex_prioritize.o
+arm-none-eabi-ar -r tx.a txe_mutex_put.o txe_queue_create.o txe_queue_delete.o txe_queue_flush.o txe_queue_front_send.o txe_queue_info_get.o txe_queue_prioritize.o
+arm-none-eabi-ar -r tx.a txe_queue_receive.o txe_queue_send.o txe_queue_send_notify.o txe_semaphore_ceiling_put.o txe_semaphore_create.o txe_semaphore_delete.o
+arm-none-eabi-ar -r tx.a txe_semaphore_get.o txe_semaphore_info_get.o txe_semaphore_prioritize.o txe_semaphore_put.o txe_semaphore_put_notify.o txe_thread_create.o
+arm-none-eabi-ar -r tx.a txe_thread_delete.o txe_thread_entry_exit_notify.o txe_thread_info_get.o txe_thread_preemption_change.o txe_thread_priority_change.o 
+arm-none-eabi-ar -r tx.a txe_thread_relinquish.o txe_thread_reset.o txe_thread_resume.o txe_thread_suspend.o txe_thread_terminate.o txe_thread_time_slice_change.o
+arm-none-eabi-ar -r tx.a txe_thread_wait_abort.o txe_timer_activate.o txe_timer_change.o txe_timer_create.o txe_timer_deactivate.o txe_timer_delete.o txe_timer_info_get.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_current_state_set.o tx_thread_smp_debug_entry_insert.o tx_thread_smp_high_level_initialize.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_rebalance_execute_list.o tx_thread_smp_core_exclude.o tx_thread_smp_core_exclude_get.o
+arm-none-eabi-ar -r tx.a tx_timer_smp_core_exclude.o tx_timer_smp_core_exclude_get.o tx_thread_smp_utilities.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_core_get.o tx_thread_smp_core_preempt.o tx_thread_smp_current_state_get.o tx_thread_smp_current_thread_get.o tx_thread_smp_initialize_wait.o
+arm-none-eabi-ar -r tx.a tx_thread_smp_low_level_initialize.o tx_thread_smp_protect.o tx_thread_smp_time_get.o tx_thread_smp_unprotect.o

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+arm-none-eabi-gcc -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a9 sample_threadx.c
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 startup.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_GIC.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_SCU.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_Mutexes.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_PrivateTimer.S
+arm-none-eabi-gcc -c -g -mcpu=cortex-a9 v7.S
+arm-none-eabi-gcc -T sample_threadx.ld -e Vectors -mcpu=cortex-a9 --specs=nosys.specs -o sample_threadx.out MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o sample_threadx.o startup.o v7.o tx.a -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
@@ -29,15 +29,16 @@ esac
 
 "${CC}" ${TARGET_FLAGS} -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a9 sample_threadx.c
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 startup.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 crt0.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_GIC.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_SCU.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_Mutexes.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_PrivateTimer.S
 "${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 v7.S
-"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a9 \
+"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a9 -nostartfiles \
     -T sample_threadx.ld \
     ${ENTRY_FLAG} \
     ${SYSCALL_LIB} \
     -o sample_threadx.out MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o \
-    sample_threadx.o startup.o v7.o tx.a \
+    sample_threadx.o startup.o crt0.o v7.o tx.a \
     -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -e
+cd "$(dirname "$0")"
 
-# this script builds the ThreadX library for the Cortex-A5 SMP port using
-# GNU toolchain or llvm/clang toolchain (defaults to gnu).
+# this script builds the ThreadX sample image for the Cortex-A9 SMP port using
+# GNU toolchain or llvm/clang toolchain (defaults to GNU).
 : "${TOOLCHAIN:=gnu}"
 case "${TOOLCHAIN}" in
     gnu)
@@ -26,11 +27,17 @@ case "${TOOLCHAIN}" in
         ;;
 esac
 
-arm-none-eabi-gcc -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a9 sample_threadx.c
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 startup.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_GIC.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_SCU.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_Mutexes.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_PrivateTimer.S
-arm-none-eabi-gcc -c -g -mcpu=cortex-a9 v7.S
-arm-none-eabi-gcc -T sample_threadx.ld -e Vectors -mcpu=cortex-a9 --specs=nosys.specs -o sample_threadx.out MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o sample_threadx.o startup.o v7.o tx.a -Wl,-M > sample_threadx.map
+"${CC}" ${TARGET_FLAGS} -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a9 sample_threadx.c
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 startup.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_GIC.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_SCU.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_Mutexes.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 MP_PrivateTimer.S
+"${CC}" ${TARGET_FLAGS} -c -g -mcpu=cortex-a9 v7.S
+"${CC}" ${TARGET_FLAGS} -g -mcpu=cortex-a9 \
+    -T sample_threadx.ld \
+    ${ENTRY_FLAG} \
+    ${SYSCALL_LIB} \
+    -o sample_threadx.out MP_PrivateTimer.o MP_GIC.o MP_Mutexes.o MP_SCU.o \
+    sample_threadx.o startup.o v7.o tx.a \
+    -Wl,-M > sample_threadx.map

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+##############################################################################
+# Copyright (c) 2026 Eclipse ThreadX contributors
+#
+# This program and the accompanying materials are made available under the
+# terms of the MIT License which is available at
+# https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: MIT
+##############################################################################
+
 set -e
 cd "$(dirname "$0")"
 

--- a/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/build_threadx_sample.sh
@@ -1,5 +1,31 @@
 #!/bin/sh
 set -e
+
+# this script builds the ThreadX library for the Cortex-A5 SMP port using
+# GNU toolchain or llvm/clang toolchain (defaults to gnu).
+: "${TOOLCHAIN:=gnu}"
+case "${TOOLCHAIN}" in
+    gnu)
+        CC="arm-none-eabi-gcc"
+        TARGET_FLAGS="" # GNU and Clang use different driver syntax for selecting the program's
+        # entry-point symbol.
+        ENTRY_FLAG="-e Vectors"
+        # Bare-metal C libraries require syscall support. GNU uses newlib's nosys stubs
+        # while ATFE requires a semihost library.
+        SYSCALL_LIB="--specs=nosys.specs"
+        ;;
+    atfe)
+        CC="${ATFE_CLANG:-clang}"
+        TARGET_FLAGS="--target=arm-none-eabi"
+        ENTRY_FLAG="-Wl,--entry=Vectors"
+        SYSCALL_LIB="-lsemihost"
+        ;;
+    *)
+        echo "Unknown TOOLCHAIN: ${TOOLCHAIN}" >&2
+        exit 1
+        ;;
+esac
+
 arm-none-eabi-gcc -c -g -I../../../../common_smp/inc -I../inc -mcpu=cortex-a9 sample_threadx.c
 arm-none-eabi-gcc -c -g -mcpu=cortex-a9 startup.S
 arm-none-eabi-gcc -c -g -mcpu=cortex-a9 MP_GIC.S

--- a/ports_smp/cortex_a9_smp/gnu/example_build/crt0.S
+++ b/ports_smp/cortex_a9_smp/gnu/example_build/crt0.S
@@ -1,0 +1,101 @@
+
+    .syntax unified
+#if defined(THUMB_MODE)
+    .thumb
+#else
+    .arm
+#endif
+
+/* .text is used instead of .section .text so it works with arm-aout too.  */
+    .text
+    .align  0
+
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global _mainCRTStartup
+_mainCRTStartup:
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global _start
+_start:
+#if defined(THUMB_MODE)
+    .thumb_func
+#endif
+    .global start
+start:
+
+/* Start by setting up a stack */
+    /*  Set up the stack pointer to a fixed value */
+    ldr r3, .LC0
+    mov     sp, r3
+    /* Setup a default stack-limit in case the code has been
+       compiled with "-mapcs-stack-check".  Hard-wiring this value
+       is not ideal, since there is currently no support for
+       checking that the heap and stack have not collided, or that
+       this default 64k is enough for the program being executed.
+       However, it ensures that this simple crt0 world will not
+       immediately cause an overflow event:  */
+    sub sl, sp, #64 << 10   /* Still assumes 256bytes below sl */
+    mov     a2, #0          /* Second arg: fill value */
+    mov fp, a2          /* Null frame pointer */
+    mov r7, a2          /* Null frame pointer for Thumb */
+
+    ldr a1, .LC1        /* First arg: start of memory block */
+    ldr a3, .LC2
+    sub a3, a3, a1      /* Third arg: length of block */
+
+
+
+        bl      memset
+    mov r0, #0      /*  no arguments  */
+    mov r1, #0      /*  no argv either */
+#ifdef __USES_INITFINI__
+    /* Some arm/elf targets use the .init and .fini sections
+       to create constructors and destructors, and for these
+       targets we need to call the _init function and arrange
+       for _fini to be called at program exit.  */
+    mov r4, r0
+    mov r5, r1
+/*        ldr     r0, .Lfini */
+        bl      atexit
+/*        bl      init */
+    mov r0, r4
+    mov r1, r5
+#endif
+        bl      main
+
+        bl      exit         /* Should not return.  */
+
+
+    /* For Thumb, constants must be after the code since only
+       positive offsets are supported for PC relative addresses.  */
+
+    .align 0
+.LC0:
+.LC1:
+    .word   __bss_start__
+.LC2:
+    .word   __bss_end__
+/*
+#ifdef __USES_INITFINI__
+.Lfini:
+    .word   _fini
+#endif  */
+    /* Return ...  */
+    bx  lr
+
+    .global  _fini
+    .type    _fini,function
+_fini:
+    BX      lr                                  // Return to caller
+
+/*  Workspace for Angel calls.  */
+    .data
+/*  Data returned by monitor SWI.  */
+.global __stack_base__
+HeapBase:   .word   0
+HeapLimit:  .word   0
+__stack_base__: .word   0
+StackLimit: .word   0


### PR DESCRIPTION
## Summary

- Add GNU/ATfE build scripts for the Cortex-A5, Cortex-A7, and Cortex-A9 SMP libraries and examples.
- Handle the lowercase assembly sources that require preprocessing on Linux.
- Add the corresponding local `crt0.S` to each example and link with `-nostartfiles`, keeping `Vectors` as the entry point.

Closes #605

## Verification

- GNU Arm Embedded GCC 13.2.1: `build_threadx.sh` and `build_threadx_sample.sh` completed for A5, A7, and A9; all three sample images linked.
- ATfE 22.1.0: `scripts/check_clang.sh` completed with 724/724 assembly sources, all feature-macro checks, all common C profiles, and 45/45 example builds passing.
- CMake example stage: Cortex-R52 linked 5/5 images.

Relevant output from `check_clang.sh`:

```text
== Assembly sources of every Arm gnu port ==
  724 of 724 assembled

== Common C sources, one core per architecture profile ==
  cortex_m0: 185 of 185 compiled
  cortex_m4: 185 of 185 compiled
  cortex_m23: 185 of 185 compiled
  cortex_m33: 185 of 185 compiled
  cortex_m55: 185 of 185 compiled
  cortex_a7: 185 of 185 compiled
  cortex_a53: 185 of 185 compiled
  cortex_r5: 185 of 185 compiled
  cortex_r52: 185 of 185 compiled

== Example builds, linked with lld ==
  45 of 45 example builds linked

== CMake example builds, linked with lld ==
  cortex_r52: 5 of 5 images linked

All LLVM toolchain checks passed.
```

NOTE: These examples were link-verified only and were not run on hardware.
