### PR TITLE
Marked every published ThreadX include directory as SYSTEM so applications no longer get warnings from ThreadX headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/${TX_COMMON_DIR})
 # Define the FreeRTOS adaptation layer
 add_library(freertos-threadx EXCLUDE_FROM_ALL)
 target_include_directories(freertos-threadx
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/utility/rtos_compatibility_layers/FreeRTOS
 )
@@ -109,6 +110,7 @@ else()
 endif()
 configure_file(${TX_USER_FILE} ${CUSTOM_INC_DIR}/tx_user.h COPYONLY)
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CUSTOM_INC_DIR}
 )

--- a/ports/arm11/gnu/CMakeLists.txt
+++ b/ports/arm11/gnu/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/arm9/gnu/CMakeLists.txt
+++ b/ports/arm9/gnu/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a12/gnu/CMakeLists.txt
+++ b/ports/cortex_a12/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a15/gnu/CMakeLists.txt
+++ b/ports/cortex_a15/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a17/gnu/CMakeLists.txt
+++ b/ports/cortex_a17/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a34/gnu/CMakeLists.txt
+++ b/ports/cortex_a34/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a35/gnu/CMakeLists.txt
+++ b/ports/cortex_a35/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a5/gnu/CMakeLists.txt
+++ b/ports/cortex_a5/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a53/gnu/CMakeLists.txt
+++ b/ports/cortex_a53/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a55/gnu/CMakeLists.txt
+++ b/ports/cortex_a55/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a57/gnu/CMakeLists.txt
+++ b/ports/cortex_a57/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a65/gnu/CMakeLists.txt
+++ b/ports/cortex_a65/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a65ae/gnu/CMakeLists.txt
+++ b/ports/cortex_a65ae/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a7/gnu/CMakeLists.txt
+++ b/ports/cortex_a7/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a72/gnu/CMakeLists.txt
+++ b/ports/cortex_a72/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a73/gnu/CMakeLists.txt
+++ b/ports/cortex_a73/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a75/gnu/CMakeLists.txt
+++ b/ports/cortex_a75/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a76/gnu/CMakeLists.txt
+++ b/ports/cortex_a76/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a76ae/gnu/CMakeLists.txt
+++ b/ports/cortex_a76ae/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a77/gnu/CMakeLists.txt
+++ b/ports/cortex_a77/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a8/gnu/CMakeLists.txt
+++ b/ports/cortex_a8/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_a9/gnu/CMakeLists.txt
+++ b/ports/cortex_a9/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m0/gnu/CMakeLists.txt
+++ b/ports/cortex_m0/gnu/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m0/iar/CMakeLists.txt
+++ b/ports/cortex_m0/iar/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m23/gnu/CMakeLists.txt
+++ b/ports/cortex_m23/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m3/gnu/CMakeLists.txt
+++ b/ports/cortex_m3/gnu/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m3/iar/CMakeLists.txt
+++ b/ports/cortex_m3/iar/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m33/ac6/CMakeLists.txt
+++ b/ports/cortex_m33/ac6/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src/tx_timer_interrupt.S
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+    SYSTEM
+    PUBLIC
     inc
 )

--- a/ports/cortex_m33/gnu/CMakeLists.txt
+++ b/ports/cortex_m33/gnu/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m4/gnu/CMakeLists.txt
+++ b/ports/cortex_m4/gnu/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m4/iar/CMakeLists.txt
+++ b/ports/cortex_m4/iar/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m52/ac6/CMakeLists.txt
+++ b/ports/cortex_m52/ac6/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src/tx_timer_interrupt.S
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+    SYSTEM
+    PUBLIC
     inc
 )

--- a/ports/cortex_m52/gnu/CMakeLists.txt
+++ b/ports/cortex_m52/gnu/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m55/ac6/CMakeLists.txt
+++ b/ports/cortex_m55/ac6/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src/tx_timer_interrupt.S
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+    SYSTEM
+    PUBLIC
     inc
 )

--- a/ports/cortex_m55/gnu/CMakeLists.txt
+++ b/ports/cortex_m55/gnu/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m7/gnu/CMakeLists.txt
+++ b/ports/cortex_m7/gnu/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     # {{END_TARGET_SOURCES}}
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+    SYSTEM
+    PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m7/iar/CMakeLists.txt
+++ b/ports/cortex_m7/iar/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_m85/ac6/CMakeLists.txt
+++ b/ports/cortex_m85/ac6/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src/tx_timer_interrupt.S
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+    SYSTEM
+    PUBLIC
     inc
 )

--- a/ports/cortex_m85/gnu/CMakeLists.txt
+++ b/ports/cortex_m85/gnu/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_r4/gnu/CMakeLists.txt
+++ b/ports/cortex_r4/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_r5/gnu/CMakeLists.txt
+++ b/ports/cortex_r5/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/cortex_r52/gnu/CMakeLists.txt
+++ b/ports/cortex_r52/gnu/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/linux/gnu/CMakeLists.txt
+++ b/ports/linux/gnu/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/rxv1/ccrx/CMakeLists.txt
+++ b/ports/rxv1/ccrx/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/rxv1/gnu/CMakeLists.txt
+++ b/ports/rxv1/gnu/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/rxv2/ccrx/CMakeLists.txt
+++ b/ports/rxv2/ccrx/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/rxv2/gnu/CMakeLists.txt
+++ b/ports/rxv2/gnu/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/rxv3/ccrx/CMakeLists.txt
+++ b/ports/rxv3/ccrx/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/rxv3/gnu/CMakeLists.txt
+++ b/ports/rxv3/gnu/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/win32/vs_2019/CMakeLists.txt
+++ b/ports/win32/vs_2019/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/win64/vs_2022/CMakeLists.txt
+++ b/ports/win64/vs_2022/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports/xtensa/xcc/CMakeLists.txt
+++ b/ports/xtensa/xcc/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_arch/ARMv7-A/threadx/ports/gnu/CMakeLists.txt
+++ b/ports_arch/ARMv7-A/threadx/ports/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_arch/ARMv7-M/threadx/gnu/CMakeLists.txt
+++ b/ports_arch/ARMv7-M/threadx/gnu/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     # {{END_TARGET_SOURCES}}
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+    SYSTEM
+    PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_arch/ARMv8-A/threadx/ports/gnu/CMakeLists.txt
+++ b/ports_arch/ARMv8-A/threadx/ports/gnu/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_arch/ARMv8-A/threadx_smp/ports/gnu/CMakeLists.txt
+++ b/ports_arch/ARMv8-A/threadx_smp/ports/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_arch/ARMv8-M/threadx/ac6/CMakeLists.txt
+++ b/ports_arch/ARMv8-M/threadx/ac6/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src/tx_timer_interrupt.S
 )
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+    SYSTEM
+    PUBLIC
     inc
 )

--- a/ports_arch/ARMv8-M/threadx/gnu/CMakeLists.txt
+++ b/ports_arch/ARMv8-M/threadx/gnu/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a34_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a34_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a35_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a35_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a53_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a53_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a55_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a55_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a57_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a57_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a5_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a5_smp/gnu/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a5x_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a5x_smp/gnu/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a65_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a65_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a65ae_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a65ae_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a72_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a72_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a73_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a73_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a75_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a75_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a76_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a76_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a76ae_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a76ae_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a77_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a77_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a78_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a78_smp/gnu/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a7_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a7_smp/gnu/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/cortex_a9_smp/gnu/CMakeLists.txt
+++ b/ports_smp/cortex_a9_smp/gnu/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/linux/gnu/CMakeLists.txt
+++ b/ports_smp/linux/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/mips32_interaptiv_smp/gnu/CMakeLists.txt
+++ b/ports_smp/mips32_interaptiv_smp/gnu/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/ports_smp/win64/vs_2022/CMakeLists.txt
+++ b/ports_smp/win64/vs_2022/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/inc
 )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,7 +35,8 @@ rm -rf /opt/hostedtoolcache
 #
 # The Acquire options are kept anyway, since they make a slow mirror give up
 # sooner. The loop covers a mirror that is down rather than merely slow. The
-# explicit exits stop a failed fetch from being carried forward into a build.
+# explicit exits stop a failed fetch from being carried forward into a build,
+# with one deliberate exception noted at the update below.
 APT_OPTIONS=(-o Acquire::Retries=3
              -o Acquire::http::Timeout=20
              -o Acquire::https::Timeout=20)
@@ -63,7 +64,31 @@ retry() {
     return 1
 }
 
-retry sudo "${TIMEOUT[@]}" apt-get "${APT_OPTIONS[@]}" update || exit 1
+# THE UPDATE IS NOT THE GATE, AND IT MUST NOT BE.  apt-get update fails if ANY
+# configured repository serves a bad index, including ones this project does
+# not use.  On a GitHub runner the image carries Google's and Microsoft's
+# repositories, and a Hash Sum mismatch from Google's -- their CDN caught
+# mid-publish, index and Release file eight hours apart -- failed this script
+# three attempts running and turned a build red over a browser nobody was
+# installing.
+#
+# The alternative of disabling third-party sources before updating is wrong
+# here: this script also runs on a contributor's own machine, where silently
+# rewriting their apt configuration would be a far worse thing to do than
+# tolerating a stale index.
+#
+# So a failed update WARNS and the install below is the gate.  Nothing is
+# weakened by that: apt-get install still fails hard on a package it cannot
+# find, so an archive that is genuinely unreachable still stops the script --
+# one step later, and saying which package it could not get.
+if ! retry sudo "${TIMEOUT[@]}" apt-get "${APT_OPTIONS[@]}" update; then
+    echo ""
+    echo "install.sh: apt-get update did not fully succeed."
+    echo "install.sh: continuing, because a repository this project does not"
+    echo "install.sh: use can fail an update.  The install below is the real"
+    echo "install.sh: gate and fails if any package needed is unavailable."
+    echo ""
+fi
 retry sudo "${TIMEOUT[@]}" apt-get "${APT_OPTIONS[@]}" install -y \
     gcc-multilib \
     git \

--- a/test/smp/cmake/threadx_smp/CMakeLists.txt
+++ b/test/smp/cmake/threadx_smp/CMakeLists.txt
@@ -45,6 +45,7 @@ else()
 endif()
 configure_file(${TX_USER_FILE} ${CUSTOM_INC_DIR}/tx_user.h COPYONLY)
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CUSTOM_INC_DIR}
 )

--- a/test/smp/cmake/threadx_smp/common_smp/CMakeLists.txt
+++ b/test/smp/cmake/threadx_smp/common_smp/CMakeLists.txt
@@ -214,6 +214,7 @@ target_sources(${PROJECT_NAME}
 
 # Add the Common/inc directory to the project include list
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CURRENT_DIR}/inc
 )

--- a/test/smp/cmake/threadx_smp/ports_smp/linux/gnu/CMakeLists.txt
+++ b/test/smp/cmake/threadx_smp/ports_smp/linux/gnu/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CURRENT_DIR}/inc
 )

--- a/test/smp/cmake/threadx_smp/ports_smp/win64/vs_2022/CMakeLists.txt
+++ b/test/smp/cmake/threadx_smp/ports_smp/win64/vs_2022/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
+    SYSTEM
     PUBLIC
     ${CURRENT_DIR}/inc
 )

--- a/utility/rtos_compatibility_layers/posix/CMakeLists.txt
+++ b/utility/rtos_compatibility_layers/posix/CMakeLists.txt
@@ -12,6 +12,7 @@
 add_library(posix-threadx EXCLUDE_FROM_ALL)
 
 target_include_directories(posix-threadx
+    SYSTEM
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
 )


### PR DESCRIPTION
Fixes #290

Commit 8c3c08f added the `SYSTEM` keyword to `target_include_directories` in `common/CMakeLists.txt`, but every other CMakeLists file that publishes a ThreadX header was left unchanged. A consumer building with a strict warning set therefore still saw diagnostics from `tx_port.h` and from the compatibility layer headers, which is precisely what that change set out to avoid.

This adds `SYSTEM` to the remaining calls, so CMake now emits `-isystem` rather than `-I` for every directory holding a ThreadX public header:

- all 60 port and SMP port directories under `ports/` and `ports_smp/`
- the four architecture sources under `ports_arch/` (ARMv7-M, ARMv8-M, ARMv7-A, ARMv8-A), keeping them in step with the ports they generate
- the POSIX and FreeRTOS compatibility layers
- the generated `tx_user.h` directory in the top-level `CMakeLists.txt`
- the parallel library build used by the SMP regression suite

Directories that are `PRIVATE` to an example or test build were left alone, since nothing is published from them.

**Validation**
- `test/tx/cmake/run.sh build` and `test`: 98/98 pass
- `test/smp/cmake/run.sh build`: 444 targets link
- `scripts/build_posix.sh`: 322 targets link. This is the interesting case, since the POSIX layer deliberately publishes replacements for `errno.h`, `pthread.h`, `sched.h`, `signal.h` and `time.h`. `-isystem` directories are still searched ahead of the toolchain's own system directories, so the override continues to work on the bare-metal targets.
- `scripts/check_ports.sh`: all checks pass, copy scripts change nothing
- Confirmed in the generated `build.ninja` that the port include directory is now passed as `-isystem`


---

## Second commit: a CI fix that had to come along

The first push went red in all three test jobs, and the cause was outside this project. Google's Chrome apt repository served a `Packages.gz` that did not match its own `Release` file, their CDN caught mid-publish. `apt-get update` fails if **any** configured repository serves a bad index, so `scripts/install.sh` failed three attempts running and nothing was built. The runner image happens to carry that repository; nothing here installs a browser.

So `apt-get update` now warns instead of aborting, and `apt-get install` is the gate. Nothing is weakened: the install still exits on a package it cannot find, so an archive that is genuinely unreachable still stops the script, one step later and naming the package it could not get, which is a better diagnostic than a hash mismatch in a repository nobody asked for.

Disabling third-party sources before updating would keep the update strict, but `install.sh` also runs on a contributor's own machine, and rewriting someone's apt configuration to suit our CI would be worse than tolerating a stale index for an archive we do not read.

This mirrors the same fix already made in ZoneX.
