### PR TITLE
Enabled the RISC-V regression suite in CI for QEMU targets

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -113,9 +113,21 @@ jobs:
       cmake_path: ./test/tx/cmake/riscv
       result_affix: RISC-V
       skip_deploy: true
-      # No coverage build configuration for the RISC-V suite yet: the CMake
-      # configurations under test/tx/cmake/riscv match the Linux suite's minus
-      # the coverage instrumentation, so gcovr has nothing to read here.
+      # No coverage from this suite, and not for want of a build configuration.
+      # These tests are bare-metal images run under QEMU with -bios none, and
+      # test/tx/cmake/riscv/bsp/syscalls.c gives them _write to the UART, _exit
+      # through the sifive_test device, and stubs for _close, _fstat, _isatty,
+      # _lseek, _read and _sbrk -- but no _open. gcov emits a .gcda by opening
+      # a path, so instrumenting these builds would produce nothing to read.
+      #
+      # test/tx/cmake/riscv/CMakeLists.txt is its own top-level project and does
+      # not declare the TX_COVERAGE option that test/tx/cmake and test/smp/cmake
+      # do, so the OFF the template exports is inert here rather than the thing
+      # holding coverage off.
+      #
+      # Collecting it therefore needs a transport off the target -- gcov's dump
+      # routines over the UART the BSP already drives, or semihosting -- and not
+      # a default_build_coverage entry beside the other five configurations.
       skip_coverage: true
   deploy:
     # Publishing the coverage report stays on master. Adding dev to this

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -97,24 +97,26 @@ jobs:
       # No coverage build configuration yet; the suite covers the creation
       # paths of the layer rather than all of it.
       skip_coverage: true
-  # riscv: disabled — re-enable when RISC-V CI is ready
-  # riscv:
-  #   permissions:
-  #     contents: read
-  #     issues: read
-  #     checks: write
-  #     pull-requests: write
-  #     pages: write
-  #     id-token: write
-  #   uses: ./.github/workflows/regression_template.yml
-  #   with:
-  #     install_script: ./scripts/install_riscv.sh
-  #     build_script: ./scripts/build_tx_riscv.sh
-  #     test_script: ./scripts/test_tx_riscv.sh
-  #     cmake_path: ./test/tx/cmake/riscv
-  #     result_affix: RISC-V
-  #     skip_deploy: true
-  #     skip_coverage: true
+  riscv:
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/regression_template.yml
+    with:
+      install_script: ./scripts/install_riscv.sh
+      build_script: ./scripts/build_tx_riscv.sh
+      test_script: ./scripts/test_tx_riscv.sh
+      cmake_path: ./test/tx/cmake/riscv
+      result_affix: RISC-V
+      skip_deploy: true
+      # No coverage build configuration for the RISC-V suite yet: the CMake
+      # configurations under test/tx/cmake/riscv match the Linux suite's minus
+      # the coverage instrumentation, so gcovr has nothing to read here.
+      skip_coverage: true
   deploy:
     # Publishing the coverage report stays on master. Adding dev to this
     # workflow's triggers was meant to run the suites on the branch the pull


### PR DESCRIPTION
This PR enables the RISC-V CI tests. It runs about 5 configurations for RV64, RV32 each with around 955 tests combined.

These use QEMU for running RV32 and RV64 tests. 