### PR TITLE
Pointed the SMP coverage comment at #677

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -77,7 +77,8 @@ jobs:
       # three are in tx_thread_smp_utilities.c: one is a range guard placed
       # after the shift it is meant to guard, so reaching it needs undefined
       # behaviour, and two are a priority-inheritance branch that needs the
-      # mutex owner genuinely executing on another core. See T17.
+      # mutex owner genuinely executing on another core. See #677, which
+      # made these measurements and raised the floor.
       coverage_thresholds: '99 100'
   freertos:
     permissions:


### PR DESCRIPTION
The paragraph explaining why the SMP coverage floor sits at 99 rather than 100 ended with a bare reference that resolves to nothing a reader of this repository can open. It named a source outside the tree in place of one inside it.

The real source is #677. That pull request wrote the four tests which closed 53 of the 64 lines, took the measurements this paragraph quotes — the 180,003 windows with zero handovers, and the three remaining lines in `tx_thread_smp_utilities.c` — and raised the floor from 98 to 99. Citing it gives the next reader somewhere to go.

This is the same correction #718 made across five other files. This line was missed there because it lives in `regression_test.yml` rather than in `regression_template.yml`.

Comment only; no behaviour change. The workflow still parses and the job inputs are untouched.
